### PR TITLE
fix(sec): upgrade jackson-databind to 2.13.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <log4j.version>2.17.1</log4j.version>
         <guava.version>31.1-jre</guava.version>
         <jackson-core.version>2.13.2</jackson-core.version>
-        <jackson-databind.version>2.13.2</jackson-databind.version>
+        <jackson-databind.version>2.13.2.1</jackson-databind.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Upgrade jackson-databind from 2.13.2 to 2.13.2.1 for vulnerability fix:
- [CVE-2020-36518](https://www.oscs1024.com/hd/MPS-2022-6242)