### PR TITLE
[fixbug]类型比较错误

### DIFF
--- a/common/src/main/java/com/dtp/common/properties/SimpleTpProperties.java
+++ b/common/src/main/java/com/dtp/common/properties/SimpleTpProperties.java
@@ -41,7 +41,7 @@ public class SimpleTpProperties {
      * this is the maximum time that excess idle threads
      * will wait for new tasks before terminating.
      */
-    private int keepAliveTime = 60;
+    private long keepAliveTime = 60;
 
     /**
      * Timeout unit.


### PR DESCRIPTION
The property keepAliveTime of SimpleTpProperties is inconsistent with the property keepAliveTime of ThreadPoolExecutor, but the==comparison occurs