### PR TITLE
[fixbug]type update

### DIFF
--- a/adapter/adapter-webserver/src/main/java/com/dtp/adapter/webserver/UndertowDtpAdapter.java
+++ b/adapter/adapter-webserver/src/main/java/com/dtp/adapter/webserver/UndertowDtpAdapter.java
@@ -126,7 +126,7 @@ public class UndertowDtpAdapter extends AbstractWebServerDtpAdapter {
                     xnioWorker.setOption(Options.WORKER_TASK_CORE_THREADS, properties.getCorePoolSize());
                 }
             }
-            int keepAlive = properties.getKeepAliveTime() * 1000;
+            int keepAlive = (int)properties.getKeepAliveTime() * 1000;
             if (!Objects.equals(xnioWorker.getOption(Options.WORKER_TASK_KEEPALIVE), keepAlive)) {
                 xnioWorker.setOption(Options.WORKER_TASK_KEEPALIVE, keepAlive);
             }

--- a/common/src/main/java/com/dtp/common/properties/SimpleTpProperties.java
+++ b/common/src/main/java/com/dtp/common/properties/SimpleTpProperties.java
@@ -41,7 +41,7 @@ public class SimpleTpProperties {
      * this is the maximum time that excess idle threads
      * will wait for new tasks before terminating.
      */
-    private int keepAliveTime = 60;
+    private long keepAliveTime = 60;
 
     /**
      * Timeout unit.


### PR DESCRIPTION
The property keepAliveTime of SimpleTpProperties is inconsistent with the property keepAliveTime of ThreadPoolExecutor, but the==comparison occurs