### PR TITLE
fix notice not send bug

### DIFF
--- a/core/src/main/java/com/dtp/core/notify/filter/NoticeBaseFilter.java
+++ b/core/src/main/java/com/dtp/core/notify/filter/NoticeBaseFilter.java
@@ -35,12 +35,15 @@ public class NoticeBaseFilter implements NotifyFilter {
                     executorWrapper.getThreadPoolName());
             return;
         }
+        if (CollectionUtils.isEmpty(notifyItem.getPlatforms()) && CollectionUtils.isEmpty(context.getPlatforms())) {
+            log.debug("DynamicTp refresh, change notification platform not found, threadPoolName: {}",
+                    executorWrapper.getThreadPoolName());
+            return;
+        }
         nextInvoker.invoke(context);
     }
 
     public boolean satisfyBaseCondition(NotifyItem notifyItem, ExecutorWrapper executor) {
-        return executor.isNotifyEnabled()
-                && notifyItem.isEnabled()
-                && CollectionUtils.isNotEmpty(notifyItem.getPlatforms());
+        return executor.isNotifyEnabled() && notifyItem.isEnabled();
     }
 }


### PR DESCRIPTION
复现问题的配置为
```yaml
# 动态线程池配置文件，建议单独开一个文件放到配置中心，字段详解看readme介绍
spring:
  dynamic:
    tp:
      enabled: true
      enabledBanner: true           # 是否开启banner打印，默认true
      enabledCollect: true          # 是否开启监控指标采集，默认false
      collectorTypes: micrometer,logging     # 监控数据采集器类型（logging | micrometer | internal_logging），默认micrometer
      logPath: /home/logs           # 监控日志数据路径，默认 ${user.home}/logs
      monitorInterval: 5            # 监控时间间隔（报警判断、指标采集），默认5s
      nacos:                        # nacos配置，不配置有默认值（规则name-dev.yml这样），cloud应用不需要配置
        dataId: dynamic-tp-nacos-demo-dtp-dev.yml
        group: DEFAULT_GROUP
      configType: yml               # 配置文件类型
      platforms:                    # 通知报警平台配置
        - platform: wechat
          urlKey: xxxx  # 替换
          receivers: xxxx                   # 接受人企微名称
      tomcatTp:                                    # tomcat web server线程池配置
        corePoolSize: 100
        maximumPoolSize: 400
        keepAliveTime: 60
      jettyTp:                                     # jetty web server线程池配置
        corePoolSize: 100
        maximumPoolSize: 400
      undertowTp:                                  # undertow web server线程池配置
        corePoolSize: 100
        maximumPoolSize: 400
        keepAliveTime: 60
      hystrixTp:                                   # hystrix 线程池配置
        - threadPoolName: hystrix1
          corePoolSize: 100
          maximumPoolSize: 400
          keepAliveTime: 60
      dubboTp:                                     # dubbo 线程池配置
        - threadPoolName: dubboTp#20880
          corePoolSize: 100
          maximumPoolSize: 400
          keepAliveTime: 60
      rocketMqTp:                                  # rocketmq 线程池配置
        - threadPoolName: group1#topic1
          corePoolSize: 200
          maximumPoolSize: 400
          keepAliveTime: 60
      executors:                                   # 动态线程池配置，都有默认值，采用默认值的可以不配置该项，减少配置量
        - threadPoolName: dtpExecutor1
          executorType: common                     # 线程池类型common、eager：适用于io密集型
          corePoolSize: 2
          maximumPoolSize: 8
          queueCapacity: 200
          queueType: VariableLinkedBlockingQueue   # 任务队列，查看源码QueueTypeEnum枚举类
          rejectedHandlerType: CallerRunsPolicy    # 拒绝策略，查看RejectedTypeEnum枚举类
          keepAliveTime: 50
          allowCoreThreadTimeOut: false                  # 是否允许核心线程池超时
          threadNamePrefix: test                         # 线程名前缀
          waitForTasksToCompleteOnShutdown: false        # 参考spring线程池设计，优雅关闭线程池
          awaitTerminationSeconds: 5                     # 单位（s）
          preStartAllCoreThreads: false                  # 是否预热所有核心线程，默认false
          runTimeout: 200                                # 任务执行超时阈值，目前只做告警用，单位（ms）
          queueTimeout: 100                              # 任务在队列等待超时阈值，目前只做告警用，单位（ms）
          taskWrapperNames: ["ttl"]                          # 任务包装器名称，集成TaskWrapper接口
```