### PR TITLE
add support for spring-cloud-tencent polaris

### DIFF
--- a/example/example-polaris-cloud/pom.xml
+++ b/example/example-polaris-cloud/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>dynamic-tp-example</artifactId>
+        <groupId>cn.dynamictp</groupId>
+        <version>1.1.0</version>
+    </parent>
+    <artifactId>dynamic-tp-example-polaris-cloud</artifactId>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.tencent.cloud</groupId>
+                <artifactId>spring-cloud-tencent-dependencies</artifactId>
+                <version>1.9.1-2021.0.5</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.tencent.cloud</groupId>
+            <artifactId>spring-cloud-starter-tencent-polaris-discovery</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.tencent.cloud</groupId>
+            <artifactId>spring-cloud-starter-tencent-polaris-config</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>cn.dynamictp</groupId>
+            <artifactId>dynamic-tp-spring-cloud-starter-polaris</artifactId>
+            <version>${dtp.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>cn.dynamictp</groupId>
+            <artifactId>dynamic-tp-spring-boot-starter-adapter-webserver</artifactId>
+            <version>${dtp.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/example/example-polaris-cloud/src/main/java/com/dtp/example/PolarisCloudExampleApplication.java
+++ b/example/example-polaris-cloud/src/main/java/com/dtp/example/PolarisCloudExampleApplication.java
@@ -1,0 +1,17 @@
+package com.dtp.example;
+
+import com.dtp.core.spring.EnableDynamicTp;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author fabian4
+ */
+@EnableDynamicTp
+@SpringBootApplication
+public class PolarisCloudExampleApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PolarisCloudExampleApplication.class, args);
+    }
+}

--- a/example/example-polaris-cloud/src/main/java/com/dtp/example/config/ThreadPoolConfiguration.java
+++ b/example/example-polaris-cloud/src/main/java/com/dtp/example/config/ThreadPoolConfiguration.java
@@ -1,0 +1,79 @@
+package com.dtp.example.config;
+
+import com.dtp.core.support.DynamicTp;
+import com.dtp.core.support.ThreadPoolBuilder;
+import com.dtp.core.support.ThreadPoolCreator;
+import com.dtp.core.thread.DtpExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static com.dtp.common.em.QueueTypeEnum.SYNCHRONOUS_QUEUE;
+
+/**
+ * @author Redick01
+ */
+@Configuration
+public class ThreadPoolConfiguration {
+
+    /**
+     * 通过{@link DynamicTp} 注解定义普通juc线程池，会享受到该框架监控功能，注解名称优先级高于方法名
+     *
+     * @return 线程池实例
+     */
+    @DynamicTp("commonExecutor")
+    @Bean
+    public ThreadPoolExecutor commonExecutor() {
+        return (ThreadPoolExecutor) Executors.newFixedThreadPool(1);
+    }
+
+    /**
+     * 通过{@link ThreadPoolCreator} 快速创建一些简单配置的动态线程池
+     * tips: 建议直接在配置中心配置就行，不用@Bean声明
+     *
+     * @return 线程池实例
+     */
+    @Bean
+    public DtpExecutor dtpExecutor1() {
+        return ThreadPoolCreator.createDynamicFast("dtpExecutor1");
+    }
+
+    /**
+     * 通过{@link ThreadPoolBuilder} 设置详细参数创建动态线程池（推荐方式），
+     * ioIntensive，参考tomcat线程池设计，实现了处理io密集型任务的线程池，具体参数可以看代码注释
+     *
+     * tips: 建议直接在配置中心配置就行，不用@Bean声明
+     * @return 线程池实例
+     */
+    @Bean
+    public DtpExecutor ioIntensiveExecutor() {
+        return ThreadPoolBuilder.newBuilder()
+                .threadPoolName("ioIntensiveExecutor")
+                .corePoolSize(20)
+                .maximumPoolSize(50)
+                .queueCapacity(2048)
+                .ioIntensive(true)
+                .buildDynamic();
+    }
+
+    /**
+     * tips: 建议直接在配置中心配置就行，不用@Bean声明
+     * @return 线程池实例
+     */
+    @Bean
+    public ThreadPoolExecutor dtpExecutor2() {
+        return ThreadPoolBuilder.newBuilder()
+                .threadPoolName("dtpExecutor2")
+                .corePoolSize(10)
+                .maximumPoolSize(15)
+                .keepAliveTime(15000)
+                .timeUnit(TimeUnit.MILLISECONDS)
+                .workQueue(SYNCHRONOUS_QUEUE.getName(), null, false, null)
+                .waitForTasksToCompleteOnShutdown(true)
+                .awaitTerminationSeconds(5)
+                .buildDynamic();
+    }
+}

--- a/example/example-polaris-cloud/src/main/java/com/dtp/example/controller/TestController.java
+++ b/example/example-polaris-cloud/src/main/java/com/dtp/example/controller/TestController.java
@@ -1,0 +1,52 @@
+package com.dtp.example.controller;
+
+import com.dtp.common.properties.DtpProperties;
+import com.dtp.core.DtpRegistry;
+import com.dtp.core.support.runnable.NamedRunnable;
+import com.dtp.core.thread.DtpExecutor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.Resource;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * @author fabian4
+ */
+@Slf4j
+@RestController
+@SuppressWarnings("all")
+public class TestController {
+
+    @Resource
+    private ThreadPoolExecutor dtpExecutor1;
+
+    @Resource
+    private DtpProperties dtpProperties;
+
+    @GetMapping("/dtp-polaris-cloud-example/test")
+    public String test() throws InterruptedException {
+//        task();
+        System.out.println(dtpProperties.getTomcatTp().getCorePoolSize());
+        return "Success";
+    }
+
+    public void task() throws InterruptedException {
+        DtpExecutor dtpExecutor2 = DtpRegistry.getDtpExecutor("dtpExecutor2");
+        for (int i = 0; i < 100; i++) {
+            Thread.sleep(100);
+            dtpExecutor1.execute(() -> {
+                log.info("i am dynamic-tp-test-1 task");
+            });
+            dtpExecutor2.execute(NamedRunnable.of(() -> {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                log.info("i am dynamic-tp-test-2 task");
+            }, "task-" + i));
+        }
+    }
+}

--- a/example/example-polaris-cloud/src/main/resources/bootstrap.yml
+++ b/example/example-polaris-cloud/src/main/resources/bootstrap.yml
@@ -1,0 +1,22 @@
+server:
+  port: 9018
+
+spring:
+  application:
+    name: dynamic-tp-polaris-cloud-demo
+  cloud:
+    polaris:
+      address: grpc://127.0.0.1:8091
+      namespace: default # 设置配置中心命名空间
+      discovery:
+        enabled: true
+      stat:
+        enabled: true
+        port: 28082
+      config:
+        auto-refresh: true # auto refresh when config file changed
+        #   目前只支持 refresh_context 模式
+        refresh-type: refresh_context
+        groups:
+          - name: ${spring.application.name} # group name
+            files: [ "config/dynamic-tp.yml" ]

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -23,6 +23,7 @@
         <module>example-consul-cloud</module>
         <module>example-etcd</module>
         <module>example-adapter</module>
+        <module>example-polaris-cloud</module>
     </modules>
 
     <build>

--- a/starter/starter-configcenter/cloud-starter-polaris/pom.xml
+++ b/starter/starter-configcenter/cloud-starter-polaris/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>cn.dynamictp</groupId>
+        <artifactId>dynamic-tp-starter-configcenter</artifactId>
+        <version>1.1.0</version>
+    </parent>
+    <artifactId>dynamic-tp-spring-cloud-starter-polaris</artifactId>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.tencent.cloud</groupId>
+                <artifactId>spring-cloud-tencent-dependencies</artifactId>
+                <version>1.9.1-2021.0.5</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>cn.dynamictp</groupId>
+            <artifactId>dynamic-tp-spring-boot-starter-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.tencent.cloud</groupId>
+            <artifactId>spring-cloud-starter-tencent-polaris-config</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/starter/starter-configcenter/cloud-starter-polaris/src/main/java/com/dtp/starter/cloud/polaris/autoconfigure/DtpAutoConfiguration.java
+++ b/starter/starter-configcenter/cloud-starter-polaris/src/main/java/com/dtp/starter/cloud/polaris/autoconfigure/DtpAutoConfiguration.java
@@ -1,0 +1,32 @@
+package com.dtp.starter.cloud.polaris.autoconfigure;
+
+import com.dtp.common.constant.DynamicTpConst;
+import com.dtp.starter.cloud.polaris.refresh.CloudPolarisRefresher;
+import com.dtp.starter.common.autoconfigure.BaseBeanAutoConfiguration;
+import com.tencent.cloud.polaris.config.config.PolarisConfigProperties;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * DtpAutoConfiguration for spring cloud polaris application.
+ *
+ * @author fabian4
+ * @since 1.0.0
+ **/
+@Configuration
+@ConditionalOnClass(PolarisConfigProperties.class)
+@ConditionalOnProperty(value = DynamicTpConst.DTP_ENABLED_PROP, matchIfMissing = true, havingValue = "true")
+@ImportAutoConfiguration({BaseBeanAutoConfiguration.class})
+public class DtpAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean()
+    @ConditionalOnProperty(value = "spring.cloud.polaris.config.enabled", matchIfMissing = true)
+    public CloudPolarisRefresher cloudPolarisRefresher() {
+        return new CloudPolarisRefresher();
+    }
+}

--- a/starter/starter-configcenter/cloud-starter-polaris/src/main/java/com/dtp/starter/cloud/polaris/refresh/CloudPolarisRefresher.java
+++ b/starter/starter-configcenter/cloud-starter-polaris/src/main/java/com/dtp/starter/cloud/polaris/refresh/CloudPolarisRefresher.java
@@ -1,0 +1,31 @@
+package com.dtp.starter.cloud.polaris.refresh;
+
+
+import com.dtp.core.refresh.AbstractRefresher;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.event.SmartApplicationListener;
+import org.springframework.lang.NonNull;
+
+/**
+ * CloudPolarisRefresher related
+ *
+ * @author fabian4
+ * @since 1.0.0
+ **/
+@Slf4j
+public class CloudPolarisRefresher extends AbstractRefresher implements SmartApplicationListener {
+
+    @Override
+    public boolean supportsEventType(@NonNull Class<? extends ApplicationEvent> eventType) {
+        return RefreshScopeRefreshedEvent.class.isAssignableFrom(eventType);
+    }
+
+    @Override
+    public void onApplicationEvent(@NonNull ApplicationEvent event) {
+        if (event instanceof RefreshScopeRefreshedEvent) {
+            doRefresh(dtpProperties);
+        }
+    }
+}

--- a/starter/starter-configcenter/cloud-starter-polaris/src/main/resources/META-INF/spring.factories
+++ b/starter/starter-configcenter/cloud-starter-polaris/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.dtp.starter.cloud.polaris.autoconfigure.DtpAutoConfiguration

--- a/starter/starter-configcenter/pom.xml
+++ b/starter/starter-configcenter/pom.xml
@@ -19,5 +19,6 @@
         <module>cloud-starter-zookeeper</module>
         <module>cloud-starter-consul</module>
         <module>starter-etcd</module>
+        <module>cloud-starter-polaris</module>
     </modules>
 </project>


### PR DESCRIPTION
Related issue: https://github.com/dromara/dynamic-tp/issues/89

**目前只支持 spring-cloud-tencent polaris 传统的 `@RefreshScope` 方式刷新配置**

https://github.com/Tencent/spring-cloud-tencent/wiki/Spring-Cloud-Tencent-Config-%E4%BD%BF%E7%94%A8%E6%96%87%E6%A1%A3#%E7%AC%AC%E4%B8%83%E6%AD%A5%E5%AE%9E%E7%8E%B0%E5%8A%A8%E6%80%81%E5%88%B7%E6%96%B0%E9%85%8D%E7%BD%AE%E8%83%BD%E5%8A%9B

spring-cloud-starter-tencent-polaris-config 1.7.1 版本（包含）之后，SCT 优化了动态刷新的实现方式。不再触发 `RefreshScopeRefreshedEvent` 事件。
只能去监听 `EnvironmentChangeEvent` 或者 `ConfigChangeSpringEvent`。但是这两个事件在被捕获到的时候并没有完全更新完毕，`doRefresh()`依然只能拿到旧的`dtpProperties`，配置更新不成功。需要等一小会才能有新的配置，也没有找到更加合适的触发点😟。