### PR TITLE
fix：由线程池submit的任务执行异常时，无法被UncaughtExceptionHandler处理

### DIFF
--- a/core/src/main/java/com/dtp/core/spring/DtpLifecycleSupport.java
+++ b/core/src/main/java/com/dtp/core/spring/DtpLifecycleSupport.java
@@ -7,14 +7,8 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.RejectedExecutionHandler;
-import java.util.concurrent.RunnableFuture;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.Objects;
+import java.util.concurrent.*;
 
 /**
  * DtpLifecycleSupport which mainly implements Spring bean's lifecycle methods,
@@ -144,5 +138,21 @@ public abstract class DtpLifecycleSupport extends ThreadPoolExecutor implements 
             }
             Thread.currentThread().interrupt();
         }
+    }
+
+    @Override
+    protected void afterExecute(Runnable r, Throwable t) {
+        if (Objects.nonNull(t)) {
+            log.error("thread {} throw exception {}", Thread.currentThread(), t);
+        }
+        if (r instanceof FutureTask) {
+            try {
+                Future<?> future = (Future<?>) r;
+                future.get();
+            } catch (Exception e) {
+                log.error("thread {} throw exception {}", Thread.currentThread(), e);
+            }
+        }
+        super.afterExecute(r, t);
     }
 }

--- a/core/src/main/java/com/dtp/core/thread/NamedThreadFactory.java
+++ b/core/src/main/java/com/dtp/core/thread/NamedThreadFactory.java
@@ -33,15 +33,12 @@ public class NamedThreadFactory implements ThreadFactory {
      */
     private final AtomicInteger seq = new AtomicInteger(1);
 
-    private final Thread.UncaughtExceptionHandler uncaughtExceptionHandler;
-
     public NamedThreadFactory(String namePrefix, boolean daemon, int priority) {
         this.daemon = daemon;
         this.priority = priority;
         SecurityManager s = System.getSecurityManager();
         group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
         this.namePrefix = namePrefix;
-        this.uncaughtExceptionHandler = new DtpUncaughtExceptionHandler();
     }
 
     public NamedThreadFactory(String namePrefix) {
@@ -58,18 +55,10 @@ public class NamedThreadFactory implements ThreadFactory {
         Thread t = new Thread(group, r, name);
         t.setDaemon(daemon);
         t.setPriority(priority);
-        t.setUncaughtExceptionHandler(uncaughtExceptionHandler);
         return t;
     }
 
     public String getNamePrefix() {
         return namePrefix;
-    }
-
-    public static class DtpUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
-        @Override
-        public void uncaughtException(Thread t, Throwable e) {
-            log.error("thread {} throw exception {}", t, e);
-        }
     }
 }


### PR DESCRIPTION
submit提交任务的时候，Runable对象被封装成了FutureTask，FutureTask里的run方法在任务执行发生异常的时候，内部吞掉了异常，而后通过setException把异常设置到了变量outcome里面，这个变量可以通过future.get获取到。