### PR TITLE
fix：由线程池submit的任务执行异常时，无法被UncaughtExceptionHandler处理

### DIFF
--- a/core/src/main/java/com/dtp/core/spring/DtpLifecycleSupport.java
+++ b/core/src/main/java/com/dtp/core/spring/DtpLifecycleSupport.java
@@ -139,20 +139,4 @@ public abstract class DtpLifecycleSupport extends ThreadPoolExecutor implements 
             Thread.currentThread().interrupt();
         }
     }
-
-    @Override
-    protected void afterExecute(Runnable r, Throwable t) {
-        if (Objects.nonNull(t)) {
-            log.error("thread {} throw exception {}", Thread.currentThread(), t);
-        }
-        if (r instanceof FutureTask) {
-            try {
-                Future<?> future = (Future<?>) r;
-                future.get();
-            } catch (Exception e) {
-                log.error("thread {} throw exception {}", Thread.currentThread(), e);
-            }
-        }
-        super.afterExecute(r, t);
-    }
 }

--- a/core/src/main/java/com/dtp/core/thread/DtpExecutor.java
+++ b/core/src/main/java/com/dtp/core/thread/DtpExecutor.java
@@ -183,18 +183,7 @@ public class DtpExecutor extends DtpLifecycleSupport implements SpringExecutor {
             }
         }
 
-        if (Objects.nonNull(t)) {
-            log.error("thread {} throw exception {}", Thread.currentThread(), t);
-        }
-        if (r instanceof FutureTask) {
-            try {
-                Future<?> future = (Future<?>) r;
-                future.get();
-            } catch (Exception e) {
-                log.error("thread {} throw exception {}", Thread.currentThread(), e);
-            }
-        }
-
+        printError(r, t);
         clearContext();
         super.afterExecute(r, t);
     }
@@ -223,6 +212,20 @@ public class DtpExecutor extends DtpLifecycleSupport implements SpringExecutor {
 
     private void clearContext() {
         MDC.remove(TRACE_ID);
+    }
+
+    private void printError(Runnable r, Throwable t) {
+        if (Objects.nonNull(t)) {
+            log.error("thread {} throw exception {}", Thread.currentThread(), t);
+        }
+        if (r instanceof FutureTask) {
+            try {
+                Future<?> future = (Future<?>) r;
+                future.get();
+            } catch (Exception e) {
+                log.error("thread {} throw exception {}", Thread.currentThread(), e);
+            }
+        }
     }
 
     public List<NotifyItem> getNotifyItems() {

--- a/core/src/main/java/com/dtp/core/thread/DtpExecutor.java
+++ b/core/src/main/java/com/dtp/core/thread/DtpExecutor.java
@@ -19,11 +19,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.MDC;
 
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionHandler;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
+import java.util.Objects;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.LongAdder;
 
 import static com.dtp.common.constant.DynamicTpConst.TRACE_ID;
@@ -185,6 +182,19 @@ public class DtpExecutor extends DtpLifecycleSupport implements SpringExecutor {
                 }
             }
         }
+
+        if (Objects.nonNull(t)) {
+            log.error("thread {} throw exception {}", Thread.currentThread(), t);
+        }
+        if (r instanceof FutureTask) {
+            try {
+                Future<?> future = (Future<?>) r;
+                future.get();
+            } catch (Exception e) {
+                log.error("thread {} throw exception {}", Thread.currentThread(), e);
+            }
+        }
+
         clearContext();
         super.afterExecute(r, t);
     }


### PR DESCRIPTION
将任务执行异常的捕获，调整放到DtpExecutor中