### PR TITLE
当组件不启用时在DtpBeanDefinitionRegistrar中也进行拦截

### DIFF
--- a/core/src/main/java/com/dtp/core/spring/DtpBeanDefinitionRegistrar.java
+++ b/core/src/main/java/com/dtp/core/spring/DtpBeanDefinitionRegistrar.java
@@ -13,6 +13,7 @@ import com.google.common.collect.Maps;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
@@ -24,6 +25,7 @@ import java.util.concurrent.BlockingQueue;
 
 import static com.dtp.common.constant.DynamicTpConst.ALLOW_CORE_THREAD_TIMEOUT;
 import static com.dtp.common.constant.DynamicTpConst.AWAIT_TERMINATION_SECONDS;
+import static com.dtp.common.constant.DynamicTpConst.DTP_ENABLED_PROP;
 import static com.dtp.common.constant.DynamicTpConst.NOTIFY_ENABLED;
 import static com.dtp.common.constant.DynamicTpConst.NOTIFY_ITEMS;
 import static com.dtp.common.constant.DynamicTpConst.PLATFORM_IDS;
@@ -56,6 +58,9 @@ public class DtpBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar
     @Override
     public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
 
+        if (!BooleanUtils.toBoolean(environment.getProperty(DTP_ENABLED_PROP, BooleanUtils.TRUE))) {
+            return;
+        }
         DtpProperties dtpProperties = new DtpProperties();
         PropertiesBinder.bindDtpProperties(environment, dtpProperties);
         val executors = dtpProperties.getExecutors();


### PR DESCRIPTION
背景：之前将dtp整合到了部门自维护的基础框架当中，也就是将@EnableDynamicTp注解直接加到了底层的SpringBootApplication启动类。这样当业务应用使用自维护框架的时候就不需要额外引入dynamic-tp了，非常方便。
但缺点是业务应用无法单独关闭dtp，因为DtpBeanDefinitionRegistrar没有被排掉，所以加了这个了拦截功能。