### PR TITLE
[ISSUE #400] 修复dubbo 2.7.5以下版本动态线程池不生效的问题

### DIFF
--- a/adapter/adapter-dubbo/src/main/java/org/dromara/dynamictp/adapter/dubbo/apache/ApacheDubboDtpAdapter.java
+++ b/adapter/adapter-dubbo/src/main/java/org/dromara/dynamictp/adapter/dubbo/apache/ApacheDubboDtpAdapter.java
@@ -115,10 +115,10 @@ public class ApacheDubboDtpAdapter extends AbstractDtpAdapter {
                         try {
                             //修改为动态线程池proxy
                             ReflectionUtil.setFieldValue(EXECUTOR_FILED_NAME, wrappedChannelHandler, proxy);
+                            putAndFinalize(genTpName(k), (ExecutorService) v, proxy);
                         } catch (IllegalAccessException e) {
                             log.error("Dynamic tp update dubbo tp failed, port={}", k, e);
                         }
-                        putAndFinalize(genTpName(k), (ExecutorService) v, proxy);
                     });
                 }
             }


### PR DESCRIPTION
## 测试结果
### dubbo动态线程池日志生效
![image-20240222111449958](https://github.com/dromara/dynamic-tp/assets/50912843/b3bd4440-6dcd-4f09-99b5-129eb85bbae7)
### 断点查看参数生效且替换为动态线程池proxy
![image-20240222112952886](https://github.com/dromara/dynamic-tp/assets/50912843/0704fda0-eefb-44c3-937f-207a45730207)
### 测试只有一个线程运行
![image-20240222111732715](https://github.com/dromara/dynamic-tp/assets/50912843/e90000d8-040b-4e7a-af69-f123514f75b1)
