### PR TITLE
[ISSUE #191] VariableLinkedBlockingQueue的take、poll方法优化

### DIFF
--- a/common/src/main/java/org/dromara/dynamictp/common/queue/VariableLinkedBlockingQueue.java
+++ b/common/src/main/java/org/dromara/dynamictp/common/queue/VariableLinkedBlockingQueue.java
@@ -505,7 +505,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
         } finally {
             takeLock.unlock();
         }
-        if (c >= capacity) {
+        if (c == capacity) {
             signalNotFull();
         }
         return x;
@@ -534,7 +534,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
         } finally {
             takeLock.unlock();
         }
-        if (c >= capacity) {
+        if (c == capacity) {
             signalNotFull();
         }
         return x;
@@ -561,7 +561,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
         } finally {
             takeLock.unlock();
         }
-        if (c >= capacity) {
+        if (c == capacity) {
             signalNotFull();
         }
         return x;


### PR DESCRIPTION
issue：#191  **VariableLinkedBlockingQueue中的take、poll方法优化**
原VariableLinkedBlockingQueue中take、poll方法代码：
~~~java
if (c >= capacity) {
    signalNotFull();
}
~~~
修改后take、poll方法代码：
~~~java
if (c == capacity) {
    signalNotFull();
}
~~~
原因：

1. `c` 的含义是：在取出元素**之前**队列中的元素数量。参考代码：`c = count.getAndDecrement();`
2.  `c == capacity` 的含义是：如果取出元素之前，元素数量等于队列容量，那么在取出元素之后会有一个空位，则可以通知等待put操作的线程插入元素。
3. `c > capacity` 的含义是：如果取出元素之前，元素数量**大于**队列容量，那么在取出元素之后依然没有空位，如果此时通知等待put操作的线程，则put操作依然失败。参考代码：`while (count.get() >= capacity) {notFull.await();}`

优化：

1. 改为c == capacity，在高并发场景下，减少不必要的线程状态切换。