### PR TITLE
Wait for all close method to be completed before shutdown the ExecutorService

### DIFF
--- a/core/src/main/java/org/dromara/dynamictp/core/spring/DtpLifecycle.java
+++ b/core/src/main/java/org/dromara/dynamictp/core/spring/DtpLifecycle.java
@@ -24,6 +24,7 @@ import org.dromara.dynamictp.core.notifier.manager.AlarmManager;
 import org.dromara.dynamictp.core.notifier.manager.NoticeManager;
 import org.dromara.dynamictp.core.support.DtpLifecycleSupport;
 import org.dromara.dynamictp.core.system.SystemMetricManager;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.SmartLifecycle;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -35,7 +36,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @since 1.1.3
  **/
 @Slf4j
-public class DtpLifecycle implements SmartLifecycle {
+public class DtpLifecycle implements SmartLifecycle, DisposableBean {
 
     private final AtomicBoolean running = new AtomicBoolean(false);
 
@@ -48,10 +49,6 @@ public class DtpLifecycle implements SmartLifecycle {
 
     @Override
     public void stop() {
-        if (this.running.compareAndSet(true, false)) {
-            shutdownInternal();
-            DtpRegistry.getAllExecutors().forEach((k, v) -> DtpLifecycleSupport.destroy(v));
-        }
     }
 
     @Override
@@ -87,7 +84,15 @@ public class DtpLifecycle implements SmartLifecycle {
      */
     @Override
     public int getPhase() {
-        return Integer.MAX_VALUE;
+        return Integer.MAX_VALUE -1;
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        if (this.running.compareAndSet(true, false)) {
+            shutdownInternal();
+            DtpRegistry.getAllExecutors().forEach((k, v) -> DtpLifecycleSupport.destroy(v));
+        }
     }
 
     public void shutdownInternal() {


### PR DESCRIPTION
TomcatWebServer等优雅下线异步逻辑，可能dynamictp线程池关闭后，但web容器还存在未释放的线程需要用到线程池，就会由于dynamictp已关闭而报错。
这里设置Phase-1，降低close调用的优先级，并且把完全shutdown线程池的时机，放到所有对象close后的销毁bean时再关闭线程池。