### PR TITLE
Fix the grpc client channel executor is shutdown

### DIFF
--- a/adapter/adapter-common/src/main/java/org/dromara/dynamictp/adapter/common/AbstractDtpAdapter.java
+++ b/adapter/adapter-common/src/main/java/org/dromara/dynamictp/adapter/common/AbstractDtpAdapter.java
@@ -172,7 +172,7 @@ public abstract class AbstractDtpAdapter implements DtpAdapter {
         putAndFinalize(tpName, executor, proxy);
     }
 
-    protected void enhanceOriginExecutorByOfferingProxy(String tpName,ThreadPoolExecutorProxy proxy, String fieldName, Object targetObj){
+    protected void enhanceOriginExecutorByOfferingProxy(String tpName, ThreadPoolExecutorProxy proxy, String fieldName, Object targetObj) {
         ReflectionUtil.setFieldValue(fieldName, targetObj, proxy);
         executors.put(tpName, new ExecutorWrapper(tpName, proxy));
     }

--- a/adapter/adapter-common/src/main/java/org/dromara/dynamictp/adapter/common/AbstractDtpAdapter.java
+++ b/adapter/adapter-common/src/main/java/org/dromara/dynamictp/adapter/common/AbstractDtpAdapter.java
@@ -172,6 +172,11 @@ public abstract class AbstractDtpAdapter implements DtpAdapter {
         putAndFinalize(tpName, executor, proxy);
     }
 
+    protected void enhanceOriginExecutorByOfferingProxy(String tpName,ThreadPoolExecutorProxy proxy, String fieldName, Object targetObj){
+        ReflectionUtil.setFieldValue(fieldName, targetObj, proxy);
+        executors.put(tpName, new ExecutorWrapper(tpName, proxy));
+    }
+
     protected void putAndFinalize(String tpName, ExecutorService origin, Executor targetForWrapper) {
         executors.put(tpName, new ExecutorWrapper(tpName, targetForWrapper));
         shutdownOriginalExecutor(origin);

--- a/adapter/adapter-grpc/src/main/java/io/grpc/internal/ChannelExecutorFetcher.java
+++ b/adapter/adapter-grpc/src/main/java/io/grpc/internal/ChannelExecutorFetcher.java
@@ -5,11 +5,10 @@ import org.dromara.dynamictp.common.util.ReflectionUtil;
 import java.util.concurrent.Executor;
 
 /**
+ * ChannelExecutorFetcher
+ *
  * @author Assassinxc
- * @title: ChannelExecutorFetcher
- * @projectName dynamic-tp
- * @description:
- * @date 2025/1/24 17:31
+ * @since 1.1.9.1
  */
 public class ChannelExecutorFetcher {
     public static Executor getManagedChannelImplExecutor(ManagedChannel channel) {

--- a/adapter/adapter-grpc/src/main/java/io/grpc/internal/ChannelExecutorFetcher.java
+++ b/adapter/adapter-grpc/src/main/java/io/grpc/internal/ChannelExecutorFetcher.java
@@ -1,0 +1,22 @@
+package io.grpc.internal;
+import io.grpc.ManagedChannel;
+import org.dromara.dynamictp.common.util.ReflectionUtil;
+
+import java.util.concurrent.Executor;
+
+/**
+ * @author Assassinxc
+ * @title: ChannelExecutorFetcher
+ * @projectName dynamic-tp
+ * @description:
+ * @date 2025/1/24 17:31
+ */
+public class ChannelExecutorFetcher {
+    public static Executor getManagedChannelImplExecutor(ManagedChannel channel) {
+        if(channel instanceof ManagedChannelImpl) {
+            return (Executor) ReflectionUtil.getFieldValue(ManagedChannelImpl.class, "executor", channel);
+        }else{
+            return null;
+        }
+    }
+}

--- a/adapter/adapter-grpc/src/main/java/io/grpc/internal/ChannelExecutorFetcher.java
+++ b/adapter/adapter-grpc/src/main/java/io/grpc/internal/ChannelExecutorFetcher.java
@@ -1,4 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.grpc.internal;
+
 import io.grpc.ManagedChannel;
 import org.dromara.dynamictp.common.util.ReflectionUtil;
 
@@ -12,9 +30,9 @@ import java.util.concurrent.Executor;
  */
 public class ChannelExecutorFetcher {
     public static Executor getManagedChannelImplExecutor(ManagedChannel channel) {
-        if(channel instanceof ManagedChannelImpl) {
+        if (channel instanceof ManagedChannelImpl) {
             return (Executor) ReflectionUtil.getFieldValue(ManagedChannelImpl.class, "executor", channel);
-        }else{
+        } else {
             return null;
         }
     }

--- a/adapter/adapter-grpc/src/main/java/org/dromara/dynamictp/adapter/grpc/GrpcDtpAdapter.java
+++ b/adapter/adapter-grpc/src/main/java/org/dromara/dynamictp/adapter/grpc/GrpcDtpAdapter.java
@@ -17,7 +17,9 @@
 
 package org.dromara.dynamictp.adapter.grpc;
 
+import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessSocketAddress;
+import io.grpc.internal.ChannelExecutorFetcher;
 import io.grpc.internal.InternalServer;
 import io.grpc.internal.ServerImpl;
 import lombok.extern.slf4j.Slf4j;
@@ -26,13 +28,14 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.dromara.dynamictp.adapter.common.AbstractDtpAdapter;
 import org.dromara.dynamictp.common.properties.DtpProperties;
 import org.dromara.dynamictp.common.util.ReflectionUtil;
+import org.dromara.dynamictp.core.support.proxy.ThreadPoolExecutorProxy;
 import org.dromara.dynamictp.jvmti.JVMTI;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
@@ -63,6 +66,7 @@ public class GrpcDtpAdapter extends AbstractDtpAdapter {
             log.warn("Cannot find beans of type ServerImpl.");
             return;
         }
+        Map<Integer, List<Executor>> proxiedMap = new HashMap<>();
         for (val serverImpl : beans) {
             val internalServer = (InternalServer) ReflectionUtil.getFieldValue(ServerImpl.class, SERVER_FIELD, serverImpl);
             String key = Optional.ofNullable(internalServer)
@@ -80,7 +84,25 @@ public class GrpcDtpAdapter extends AbstractDtpAdapter {
             }
             val executor = (Executor) ReflectionUtil.getFieldValue(ServerImpl.class, EXECUTOR_FIELD, serverImpl);
             if (Objects.nonNull(executor) && executor instanceof ThreadPoolExecutor) {
-                enhanceOriginExecutor(genTpName(key), (ThreadPoolExecutor) executor, EXECUTOR_FIELD, serverImpl);
+                enhanceOriginExecutorByOfferingProxy(genTpName(key),
+                        new ThreadPoolExecutorProxy((ThreadPoolExecutor) executor), EXECUTOR_FIELD, serverImpl);
+                proxiedMap.computeIfAbsent(executor.hashCode(), k -> new ArrayList<>()).add(executor);
+            }
+        }
+        if (!proxiedMap.isEmpty()) {
+            val clientBeans = JVMTI.getInstances(ManagedChannel.class);
+            if (!clientBeans.isEmpty()) {
+                for (val channelImpl : clientBeans) {
+                    val executor = ChannelExecutorFetcher.getManagedChannelImplExecutor(channelImpl);
+                    if (Objects.nonNull(executor) && executor instanceof ThreadPoolExecutor && proxiedMap.containsKey(executor.hashCode())) {
+                        proxiedMap.get(executor.hashCode()).removeIf(proxiedExecutor -> Objects.equals(executor, proxiedExecutor));
+                    }
+                }
+            }
+            for (List<Executor> executorList : proxiedMap.values()) {
+                for (Executor executor : executorList) {
+                    shutdownOriginalExecutor((ExecutorService) executor);
+                }
             }
         }
     }

--- a/adapter/adapter-grpc/src/main/java/org/dromara/dynamictp/adapter/grpc/GrpcDtpAdapter.java
+++ b/adapter/adapter-grpc/src/main/java/org/dromara/dynamictp/adapter/grpc/GrpcDtpAdapter.java
@@ -33,7 +33,12 @@ import org.dromara.dynamictp.jvmti.JVMTI;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;


### PR DESCRIPTION
#382 
By default, grpc server and client use the same threadpool that is from the SharedResourcePool, ServerImplBuilder's executorPool field and ManagedChannelImplBuilder.build() show that. when dynamictp enhance the grpc serverImpl's threadpool, it shutdown the origin threadpool, so the threadpool(the same one) in ManagedChannelImpl is also shutdown.
![image](https://github.com/user-attachments/assets/1c663ded-cc85-4309-aca0-9f20bef4c391)
![image](https://github.com/user-attachments/assets/1e3efdb7-5374-4e09-95dd-2f8440b55dbb)

so, before finalize the threadpool,  I check that whether the origin threadpool is used in ChannelImpl.
