### PR TITLE
Fix the thread pool statistics not cached when the registration fails

### DIFF
--- a/core/src/main/java/org/dromara/dynamictp/core/monitor/collector/jmx/JMXCollector.java
+++ b/core/src/main/java/org/dromara/dynamictp/core/monitor/collector/jmx/JMXCollector.java
@@ -56,10 +56,10 @@ public class JMXCollector extends AbstractCollector {
                 ObjectName name = new ObjectName(DTP_METRIC_NAME_PREFIX + ":name=" + threadPoolStats.getPoolName());
                 ThreadPoolStatsJMX stats = new ThreadPoolStatsJMX(threadPoolStats);
                 server.registerMBean(stats, name);
+                GAUGE_CACHE.put(threadPoolStats.getPoolName(), threadPoolStats);
             } catch (JMException e) {
                 log.error("collect thread pool stats error", e);
             }
-            GAUGE_CACHE.put(threadPoolStats.getPoolName(), threadPoolStats);
         }
     }
 

--- a/test/test-core/src/test/java/org/dromara/dynamictp/test/core/monitor/collector/jmx/JMXCollectorTest.java
+++ b/test/test-core/src/test/java/org/dromara/dynamictp/test/core/monitor/collector/jmx/JMXCollectorTest.java
@@ -82,6 +82,29 @@ class JMXCollectorTest {
         }
     }
 
+    @Test
+    void testCollectDoesNotCacheStatsWhenRegistrationFails() throws Exception {
+        String poolName = "jmx-duplicate-" + UUID.randomUUID();
+        ObjectName objectName = new ObjectName(JMXCollector.DTP_METRIC_NAME_PREFIX + ":name=" + poolName);
+        Map<String, ThreadPoolStats> gaugeCache = getGaugeCache();
+        gaugeCache.remove(poolName);
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+
+        try {
+            server.registerMBean(new ThreadPoolStatsJMX(stats(poolName, 1)), objectName);
+
+            JMXCollector collector = new JMXCollector();
+            collector.collect(stats(poolName, 2));
+
+            Assertions.assertFalse(gaugeCache.containsKey(poolName));
+        } finally {
+            gaugeCache.remove(poolName);
+            if (server.isRegistered(objectName)) {
+                server.unregisterMBean(objectName);
+            }
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private static Map<String, ThreadPoolStats> getGaugeCache() throws Exception {
         Field field = JMXCollector.class.getDeclaredField("GAUGE_CACHE");


### PR DESCRIPTION
1. Fix the thread pool statistics not cached when the registration fails
2. Add unit test