### PR TITLE
refactor: 移除 Hutool 依赖（core和http），改用原生 Java 及轻量库实现

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -41,14 +41,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>fastjson</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>cn.hutool</groupId>
-            <artifactId>hutool-http</artifactId>
+            <groupId>com.alibaba.fastjson2</groupId>
+            <artifactId>fastjson2</artifactId>
         </dependency>
 
         <dependency>

--- a/common/src/main/java/org/dromara/dynamictp/common/notifier/AbstractHttpNotifier.java
+++ b/common/src/main/java/org/dromara/dynamictp/common/notifier/AbstractHttpNotifier.java
@@ -17,15 +17,19 @@
 
 package org.dromara.dynamictp.common.notifier;
 
-import cn.hutool.http.HttpRequest;
-import cn.hutool.http.HttpResponse;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.dromara.dynamictp.common.entity.NotifyPlatform;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
-import java.util.Objects;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 /**
  * The notification is sent over http
@@ -40,17 +44,60 @@ public abstract class AbstractHttpNotifier extends AbstractNotifier {
     protected void send0(NotifyPlatform platform, String content) {
         val url = buildUrl(platform);
         val msgBody = buildMsgBody(platform, content);
-        HttpRequest request = HttpRequest.post(url)
-                .setConnectionTimeout(platform.getTimeout())
-                .setReadTimeout(platform.getTimeout())
-                .body(msgBody);
-        if (platform.getProxyType() != Proxy.Type.DIRECT) {
-            request.setProxy(new Proxy(platform.getProxyType(), new InetSocketAddress(platform.getProxyHost(), platform.getProxyPort())));
+        HttpURLConnection conn = null;
+        try {
+            URL targetUrl = new URL(url);
+            if (platform.getProxyType() != Proxy.Type.DIRECT) {
+                Proxy proxy = new Proxy(platform.getProxyType(),
+                        new InetSocketAddress(platform.getProxyHost(), platform.getProxyPort()));
+                conn = (HttpURLConnection) targetUrl.openConnection(proxy);
+            } else {
+                // no explicit proxy — respect JVM system proxy settings (-Dhttp.proxyHost etc.)
+                conn = (HttpURLConnection) targetUrl.openConnection();
+            }
+            conn.setRequestMethod("POST");
+            conn.setConnectTimeout(platform.getTimeout());
+            conn.setReadTimeout(platform.getTimeout());
+            conn.setDoOutput(true);
+            conn.setUseCaches(false);
+            conn.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+            conn.setRequestProperty("User-Agent", "DynamicTp");
+
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(msgBody.getBytes(StandardCharsets.UTF_8));
+            }
+
+            int respCode = conn.getResponseCode();
+            String respBody = readResponseBody(conn, respCode);
+            if (respCode >= 200 && respCode < 300) {
+                log.info("DynamicTp notify, {} send success, response: {}, request: {}",
+                        platform(), respBody, msgBody);
+            } else {
+                log.error("DynamicTp notify, {} send failed, http status: {}, response: {}, request: {}",
+                        platform(), respCode, respBody, msgBody);
+            }
+        } catch (Exception e) {
+            log.error("DynamicTp notify, {} send failed, request: {}", platform(), msgBody, e);
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
         }
-        HttpResponse response = request.execute();
-        if (Objects.nonNull(response)) {
-            log.info("DynamicTp notify, {} send success, response: {}, request: {}",
-                    platform(), response.body(), msgBody);
+    }
+
+    private String readResponseBody(HttpURLConnection conn, int code) throws IOException {
+        InputStream is = (code >= 200 && code < 400) ? conn.getInputStream() : conn.getErrorStream();
+        if (is == null) {
+            return "";
+        }
+        try (InputStream in = is) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = in.read(buffer)) != -1) {
+                baos.write(buffer, 0, len);
+            }
+            return baos.toString(StandardCharsets.UTF_8.name());
         }
     }
 

--- a/common/src/main/java/org/dromara/dynamictp/common/notifier/DingNotifier.java
+++ b/common/src/main/java/org/dromara/dynamictp/common/notifier/DingNotifier.java
@@ -17,7 +17,6 @@
 
 package org.dromara.dynamictp.common.notifier;
 
-import cn.hutool.core.net.url.UrlBuilder;
 import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -28,6 +27,7 @@ import org.dromara.dynamictp.common.entity.MarkdownReq;
 import org.dromara.dynamictp.common.entity.NotifyPlatform;
 import org.dromara.dynamictp.common.util.DingSignUtil;
 import org.dromara.dynamictp.common.util.JsonUtil;
+import org.dromara.dynamictp.common.util.UrlBuilder;
 
 import java.util.List;
 import java.util.Optional;
@@ -88,7 +88,7 @@ public class DingNotifier extends AbstractHttpNotifier {
      */
     private String getTargetUrl(String secret, String accessToken, String webhook) {
         UrlBuilder builder = UrlBuilder.of(webhook);
-        if (StringUtils.isNotBlank(accessToken) && StringUtils.isBlank(builder.getQuery().get(DingNotifyConst.ACCESS_TOKEN_PARAM))) {
+        if (StringUtils.isNotBlank(accessToken) && StringUtils.isBlank(builder.getQueryParam(DingNotifyConst.ACCESS_TOKEN_PARAM))) {
             builder.addQuery(DingNotifyConst.ACCESS_TOKEN_PARAM, accessToken);
         }
         if (StringUtils.isNotBlank(secret)) {

--- a/common/src/main/java/org/dromara/dynamictp/common/notifier/LarkNotifier.java
+++ b/common/src/main/java/org/dromara/dynamictp/common/notifier/LarkNotifier.java
@@ -17,7 +17,6 @@
 
 package org.dromara.dynamictp.common.notifier;
 
-import cn.hutool.core.net.url.UrlBuilder;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.codec.binary.Base64;
@@ -25,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.dromara.dynamictp.common.constant.LarkNotifyConst;
 import org.dromara.dynamictp.common.em.NotifyPlatformEnum;
 import org.dromara.dynamictp.common.entity.NotifyPlatform;
+import org.dromara.dynamictp.common.util.UrlBuilder;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -101,7 +101,7 @@ public class LarkNotifier extends AbstractHttpNotifier {
             return platform.getWebhook();
         }
         UrlBuilder builder = UrlBuilder.of(Optional.ofNullable(platform.getWebhook()).orElse(LarkNotifyConst.LARK_WEBHOOK));
-        List<String> segments = builder.getPath().getSegments();
+        List<String> segments = builder.getPathSegments();
         if (!Objects.equals(platform.getUrlKey(), segments.get(segments.size() - 1))) {
            builder.addPath(platform.getUrlKey());
         }

--- a/common/src/main/java/org/dromara/dynamictp/common/notifier/WechatNotifier.java
+++ b/common/src/main/java/org/dromara/dynamictp/common/notifier/WechatNotifier.java
@@ -17,7 +17,6 @@
 
 package org.dromara.dynamictp.common.notifier;
 
-import cn.hutool.core.net.url.UrlBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.dromara.dynamictp.common.constant.WechatNotifyConst;
@@ -25,6 +24,7 @@ import org.dromara.dynamictp.common.em.NotifyPlatformEnum;
 import org.dromara.dynamictp.common.entity.MarkdownReq;
 import org.dromara.dynamictp.common.entity.NotifyPlatform;
 import org.dromara.dynamictp.common.util.JsonUtil;
+import org.dromara.dynamictp.common.util.UrlBuilder;
 
 import java.util.Optional;
 
@@ -58,7 +58,7 @@ public class WechatNotifier extends AbstractHttpNotifier {
             return platform.getWebhook();
         }
         UrlBuilder builder = UrlBuilder.of(Optional.ofNullable(platform.getWebhook()).orElse(WechatNotifyConst.WECHAT_WEB_HOOK));
-        if (StringUtils.isBlank(builder.getQuery().get(WechatNotifyConst.KEY_PARAM))) {
+        if (StringUtils.isBlank(builder.getQueryParam(WechatNotifyConst.KEY_PARAM))) {
             builder.addQuery(WechatNotifyConst.KEY_PARAM, platform.getUrlKey());
         }
         return builder.build();

--- a/common/src/main/java/org/dromara/dynamictp/common/parser/json/FastJsonParser.java
+++ b/common/src/main/java/org/dromara/dynamictp/common/parser/json/FastJsonParser.java
@@ -17,8 +17,7 @@
 
 package org.dromara.dynamictp.common.parser.json;
 
-import com.alibaba.fastjson.JSON;
-import com.alibaba.fastjson.serializer.SerializerFeature;
+import com.alibaba.fastjson2.JSON;
 
 import java.lang.reflect.Type;
 
@@ -29,7 +28,7 @@ import java.lang.reflect.Type;
  */
 public class FastJsonParser extends AbstractJsonParser {
 
-    private static final String PACKAGE_NAME = "com.alibaba.fastjson.JSON";
+    private static final String PACKAGE_NAME = "com.alibaba.fastjson2.JSON";
 
     @Override
     public <T> T fromJson(String json, Type typeOfT) {
@@ -38,7 +37,7 @@ public class FastJsonParser extends AbstractJsonParser {
 
     @Override
     public String toJson(Object obj) {
-        return JSON.toJSONString(obj, SerializerFeature.WriteDateUseDateFormat, SerializerFeature.DisableCircularReferenceDetect);
+        return JSON.toJSONString(obj, "yyyy-MM-dd HH:mm:ss");
     }
 
     @Override

--- a/common/src/main/java/org/dromara/dynamictp/common/util/BeanUtil.java
+++ b/common/src/main/java/org/dromara/dynamictp/common/util/BeanUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dromara.dynamictp.common.util;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONWriter;
+
+/**
+ * Bean utility for copying properties between objects.
+ * <p>
+ * Uses fastjson2's {@link JSONObject#copyTo(Object)} under the hood.
+ * {@link JSONWriter.Feature#WriteNulls} is enabled to preserve null-overwrite
+ * semantics (matching the original hutool BeanUtil behavior).
+ *
+ * @author dynamic-tp
+ * @since 1.2.3
+ */
+public final class BeanUtil {
+
+    private BeanUtil() {
+    }
+
+    /**
+     * Copy properties from source to target, including null values (overwriting target with null).
+     *
+     * @param source the source object
+     * @param target the target object
+     */
+    public static void copyProperties(Object source, Object target) {
+        copyProperties(source, target, true);
+    }
+
+    /**
+     * Copy properties from source to target.
+     *
+     * @param source      the source object
+     * @param target      the target object
+     * @param writeNulls  if {@code true}, null property values in source will overwrite
+     *                    the corresponding target properties (matching hutool BeanUtil behavior);
+     *                    if {@code false}, null values are skipped
+     */
+    public static void copyProperties(Object source, Object target, boolean writeNulls) {
+        JSONWriter.Feature[] features = writeNulls
+                ? new JSONWriter.Feature[]{JSONWriter.Feature.WriteNulls}
+                : new JSONWriter.Feature[]{};
+        JSONObject jsonObj = (JSONObject) JSON.toJSON(source, features);
+        jsonObj.copyTo(target);
+    }
+}

--- a/common/src/main/java/org/dromara/dynamictp/common/util/DtpPropertiesBinderUtil.java
+++ b/common/src/main/java/org/dromara/dynamictp/common/util/DtpPropertiesBinderUtil.java
@@ -17,7 +17,6 @@
 
 package org.dromara.dynamictp.common.util;
 
-import cn.hutool.core.util.ReflectUtil;
 import lombok.val;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -89,7 +88,7 @@ public final class DtpPropertiesBinderUtil {
         val tpExecutorPropFields = ReflectionUtil.getAllFields(TpExecutorProps.class);
         val globalExecutorProps = dtpProperties.getGlobalExecutorProps();
         dtpPropertiesFields.forEach(dtpPropertiesField -> {
-            val candidateExecutor = ReflectUtil.getFieldValue(dtpProperties, dtpPropertiesField);
+            val candidateExecutor = ReflectionUtil.getFieldValue(dtpPropertiesField.getName(), dtpProperties);
             if (Objects.isNull(candidateExecutor)) {
                 return;
             }
@@ -146,30 +145,30 @@ public final class DtpPropertiesBinderUtil {
         if (Objects.isNull(globalFieldVal)) {
             return;
         }
-        ReflectUtil.setFieldValue(executor, field.getName(), globalFieldVal);
+        ReflectionUtil.setFieldValue(field.getName(), executor, globalFieldVal);
     }
 
     private static void setCollectionField(Object source, DtpExecutorProps globalExecutorProps, Object executor, String prefix) {
         if (isNotContains(prefix + ".taskWrapperNames[0]", source) &&
                 CollectionUtils.isNotEmpty(globalExecutorProps.getTaskWrapperNames())) {
-            ReflectUtil.setFieldValue(executor, "taskWrapperNames", globalExecutorProps.getTaskWrapperNames());
+            ReflectionUtil.setFieldValue("taskWrapperNames", executor, globalExecutorProps.getTaskWrapperNames());
         }
         if (isNotContains(prefix + ".platformIds[0]", source) &&
                 CollectionUtils.isNotEmpty(globalExecutorProps.getPlatformIds())) {
-            ReflectUtil.setFieldValue(executor, PLATFORM_IDS, globalExecutorProps.getPlatformIds());
+            ReflectionUtil.setFieldValue(PLATFORM_IDS, executor, globalExecutorProps.getPlatformIds());
         }
         if (isNotContains(prefix + ".notifyItems[0].type", source) &&
                 CollectionUtils.isNotEmpty(globalExecutorProps.getNotifyItems())) {
-            ReflectUtil.setFieldValue(executor, NOTIFY_ITEMS, globalExecutorProps.getNotifyItems());
+            ReflectionUtil.setFieldValue(NOTIFY_ITEMS, executor, globalExecutorProps.getNotifyItems());
         }
         if (isNotContains(prefix + ".awareNames[0]", source) &&
                 CollectionUtils.isNotEmpty(globalExecutorProps.getAwareNames())) {
-            ReflectUtil.setFieldValue(executor, AWARE_NAMES, globalExecutorProps.getAwareNames());
+            ReflectionUtil.setFieldValue(AWARE_NAMES, executor, globalExecutorProps.getAwareNames());
         }
         try {
             if (isNotContains(prefix + ".pluginNames[0]", source) &&
                     CollectionUtils.isNotEmpty(globalExecutorProps.getPluginNames())) {
-                ReflectUtil.setFieldValue(executor, PLUGIN_NAMES, globalExecutorProps.getPluginNames());
+                ReflectionUtil.setFieldValue(PLUGIN_NAMES, executor, globalExecutorProps.getPluginNames());
             }
         } catch (Exception e) {
             // ignore

--- a/common/src/main/java/org/dromara/dynamictp/common/util/UrlBuilder.java
+++ b/common/src/main/java/org/dromara/dynamictp/common/util/UrlBuilder.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dromara.dynamictp.common.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Lightweight URL builder for constructing and modifying URLs.
+ * <p>
+ * Extracted from Hutool's UrlBuilder to remove the Hutool dependency.
+ * Only supports the subset of features used by dynamic-tp notifiers:
+ * parsing an existing URL, reading/adding query params, reading/adding path segments,
+ * and rebuilding the final URL string.
+ *
+ * @author dynamic-tp
+ * @since 1.2.3
+ */
+public final class UrlBuilder {
+
+    /** scheme://host[:port] part, e.g. "https://oapi.dingtalk.com" */
+    private final String origin;
+
+    private final List<String> pathSegments = new ArrayList<>();
+
+    private final Map<String, String> queryParams = new LinkedHashMap<>();
+
+    private UrlBuilder(String url) {
+        int queryIndex = url.indexOf('?');
+        String urlWithoutQuery = queryIndex >= 0 ? url.substring(0, queryIndex) : url;
+
+        // split origin and path
+        int schemeEnd = urlWithoutQuery.indexOf("://");
+        int hostStart = schemeEnd >= 0 ? schemeEnd + 3 : 0;
+        int slashIndex = urlWithoutQuery.indexOf('/', hostStart);
+        if (slashIndex >= 0) {
+            origin = urlWithoutQuery.substring(0, slashIndex);
+            parsePath(urlWithoutQuery.substring(slashIndex + 1));
+        } else {
+            origin = urlWithoutQuery;
+        }
+
+        if (queryIndex >= 0) {
+            parseQuery(url.substring(queryIndex + 1));
+        }
+    }
+
+    /**
+     * Create a UrlBuilder from an existing URL string.
+     *
+     * @param url the URL to parse
+     * @return a new UrlBuilder
+     */
+    public static UrlBuilder of(String url) {
+        return new UrlBuilder(url);
+    }
+
+    private void parsePath(String path) {
+        for (String segment : path.split("/")) {
+            if (!segment.isEmpty()) {
+                pathSegments.add(segment);
+            }
+        }
+    }
+
+    private void parseQuery(String query) {
+        if (query.isEmpty()) {
+            return;
+        }
+        for (String pair : query.split("&")) {
+            int eq = pair.indexOf('=');
+            if (eq > 0) {
+                queryParams.put(pair.substring(0, eq), pair.substring(eq + 1));
+            } else if (!pair.isEmpty()) {
+                queryParams.put(pair, "");
+            }
+        }
+    }
+
+    /**
+     * Get a query parameter value by key.
+     *
+     * @param key query parameter name
+     * @return the value, or null if not present
+     */
+    public String getQueryParam(String key) {
+        return queryParams.get(key);
+    }
+
+    /**
+     * Add a query parameter. If the key already exists, its value is replaced.
+     *
+     * @param key   query parameter name
+     * @param value query parameter value
+     * @return this builder for chaining
+     */
+    public UrlBuilder addQuery(String key, Object value) {
+        queryParams.put(key, String.valueOf(value));
+        return this;
+    }
+
+    /**
+     * Get the path segments.
+     *
+     * @return unmodifiable list of path segments
+     */
+    public List<String> getPathSegments() {
+        return Collections.unmodifiableList(pathSegments);
+    }
+
+    /**
+     * Append a path segment.
+     *
+     * @param segment the path segment to add
+     * @return this builder for chaining
+     */
+    public UrlBuilder addPath(String segment) {
+        pathSegments.add(segment);
+        return this;
+    }
+
+    /**
+     * Rebuild the full URL string from the current state.
+     *
+     * @return the full URL
+     */
+    public String build() {
+        StringBuilder sb = new StringBuilder(origin);
+        for (String segment : pathSegments) {
+            sb.append('/').append(segment);
+        }
+        if (!queryParams.isEmpty()) {
+            sb.append('?');
+            boolean first = true;
+            for (Map.Entry<String, String> entry : queryParams.entrySet()) {
+                if (!first) {
+                    sb.append('&');
+                }
+                sb.append(entry.getKey()).append('=').append(entry.getValue());
+                first = false;
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,11 +38,6 @@
         </dependency>
 
         <dependency>
-            <groupId>cn.hutool</groupId>
-            <artifactId>hutool-core</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>

--- a/core/src/main/java/org/dromara/dynamictp/core/aware/TaskRejectAware.java
+++ b/core/src/main/java/org/dromara/dynamictp/core/aware/TaskRejectAware.java
@@ -17,7 +17,6 @@
 
 package org.dromara.dynamictp.core.aware;
 
-import cn.hutool.core.text.CharSequenceUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.dromara.dynamictp.core.notifier.manager.AlarmManager;
 import org.dromara.dynamictp.core.support.adapter.ExecutorAdapter;
@@ -59,10 +58,10 @@ public class TaskRejectAware extends TaskStatAware {
         statProvider.incRejectCount(1);
         AlarmManager.tryAlarmAsync(statProvider.getExecutorWrapper(), REJECT, runnable);
         ExecutorAdapter<?> executorAdapter = statProvider.getExecutorWrapper().getExecutor();
-        String logMsg = CharSequenceUtil.format("DynamicTp execute, thread pool is exhausted, tpName: {},  traceId: {}, " +
-                        "poolSize: {} (active: {}, core: {}, max: {}, largest: {}), " +
-                        "task: {} (completed: {}), queueCapacity: {}, (currSize: {}, remaining: {}) ," +
-                        "executorStatus: (isShutdown: {}, isTerminated: {}, isTerminating: {})",
+        String logMsg = String.format("DynamicTp execute, thread pool is exhausted, tpName: %s,  traceId: %s, " +
+                        "poolSize: %s (active: %s, core: %s, max: %s, largest: %s), " +
+                        "task: %s (completed: %s), queueCapacity: %s, (currSize: %s, remaining: %s) ," +
+                        "executorStatus: (isShutdown: %s, isTerminated: %s, isTerminating: %s)",
                 statProvider.getExecutorWrapper().getThreadPoolName(), MDC.get(TRACE_ID), executorAdapter.getPoolSize(),
                 executorAdapter.getActiveCount(), executorAdapter.getCorePoolSize(), executorAdapter.getMaximumPoolSize(),
                 executorAdapter.getLargestPoolSize(), executorAdapter.getTaskCount(), executorAdapter.getCompletedTaskCount(),

--- a/core/src/main/java/org/dromara/dynamictp/core/monitor/collector/MicroMeterCollector.java
+++ b/core/src/main/java/org/dromara/dynamictp/core/monitor/collector/MicroMeterCollector.java
@@ -17,7 +17,7 @@
 
 package org.dromara.dynamictp.core.monitor.collector;
 
-import cn.hutool.core.bean.BeanUtil;
+import org.dromara.dynamictp.common.util.BeanUtil;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import lombok.extern.slf4j.Slf4j;

--- a/core/src/main/java/org/dromara/dynamictp/core/monitor/collector/jmx/JMXCollector.java
+++ b/core/src/main/java/org/dromara/dynamictp/core/monitor/collector/jmx/JMXCollector.java
@@ -17,7 +17,7 @@
 
 package org.dromara.dynamictp.core.monitor.collector.jmx;
 
-import cn.hutool.core.bean.BeanUtil;
+import org.dromara.dynamictp.common.util.BeanUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.dromara.dynamictp.common.em.CollectorTypeEnum;
 import org.dromara.dynamictp.common.entity.ThreadPoolStats;

--- a/core/src/main/java/org/dromara/dynamictp/core/notifier/AbstractDtpNotifier.java
+++ b/core/src/main/java/org/dromara/dynamictp/core/notifier/AbstractDtpNotifier.java
@@ -17,7 +17,7 @@
 
 package org.dromara.dynamictp.core.notifier;
 
-import cn.hutool.core.bean.BeanUtil;
+import org.dromara.dynamictp.common.util.BeanUtil;
 import com.google.common.base.Joiner;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;

--- a/core/src/main/java/org/dromara/dynamictp/core/notifier/manager/AlarmManager.java
+++ b/core/src/main/java/org/dromara/dynamictp/core/notifier/manager/AlarmManager.java
@@ -17,7 +17,6 @@
 
 package org.dromara.dynamictp.core.notifier.manager;
 
-import cn.hutool.core.util.NumberUtil;
 import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -35,6 +34,8 @@ import org.dromara.dynamictp.core.support.task.runnable.DtpRunnable;
 import org.dromara.dynamictp.core.support.task.wrapper.TaskWrappers;
 import org.slf4j.MDC;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
@@ -157,7 +158,9 @@ public class AlarmManager {
     private static boolean checkLiveness(ExecutorWrapper executorWrapper, NotifyItem notifyItem) {
         val executor = executorWrapper.getExecutor();
         int maximumPoolSize = executor.getMaximumPoolSize();
-        double div = NumberUtil.div(executor.getActiveCount(), maximumPoolSize, 2) * 100;
+        double div = BigDecimal.valueOf(executor.getActiveCount())
+                .divide(BigDecimal.valueOf(maximumPoolSize), 2, RoundingMode.HALF_UP)
+                .doubleValue() * 100;
         if (div >= notifyItem.getThreshold()) {
             log.warn("DynamicTp monitor, current liveness [{}] >= threshold [{}], threadPoolName: {}",
                     div, notifyItem.getThreshold(), executorWrapper.getThreadPoolName());
@@ -171,7 +174,9 @@ public class AlarmManager {
         if (executor.getQueueSize() <= 0) {
             return false;
         }
-        double div = NumberUtil.div(executor.getQueueSize(), executor.getQueueCapacity(), 2) * 100;
+        double div = BigDecimal.valueOf(executor.getQueueSize())
+                .divide(BigDecimal.valueOf(executor.getQueueCapacity()), 2, RoundingMode.HALF_UP)
+                .doubleValue() * 100;
         if (div >= notifyItem.getThreshold()) {
             log.warn("DynamicTp monitor, current queue utilization [{}] >= threshold [{}], threadPoolName: {}",
                     div, notifyItem.getThreshold(), executorWrapper.getThreadPoolName());

--- a/core/src/main/java/org/dromara/dynamictp/core/support/ExecutorWrapper.java
+++ b/core/src/main/java/org/dromara/dynamictp/core/support/ExecutorWrapper.java
@@ -17,8 +17,9 @@
 
 package org.dromara.dynamictp.core.support;
 
-import cn.hutool.core.bean.BeanUtil;
+import com.alibaba.fastjson2.annotation.JSONField;
 import lombok.Data;
+import org.dromara.dynamictp.common.util.BeanUtil;
 import org.dromara.dynamictp.common.em.NotifyItemEnum;
 import org.dromara.dynamictp.common.entity.NotifyItem;
 import org.dromara.dynamictp.core.aware.AwareManager;
@@ -61,7 +62,11 @@ public class ExecutorWrapper {
 
     /**
      * Executor.
+     * <p>
+     * serialize=false: prevents circular reference / stack overflow when JSON serialization
+     * deeply traverses ThreadPoolExecutor internal state.
      */
+    @JSONField(serialize = false)
     private ExecutorAdapter<?> executor;
 
     /**
@@ -103,8 +108,12 @@ public class ExecutorWrapper {
     protected int awaitTerminationSeconds = 0;
 
     /**
-     * Thread pool stat provider
+     * Thread pool stat provider.
+     * <p>
+     * serialize=false: ThreadPoolStatProvider holds a back-reference to this class,
+     * which would cause a circular reference and stack overflow during JSON serialization.
      */
+    @JSONField(serialize = false)
     private ThreadPoolStatProvider threadPoolStatProvider;
 
     private ExecutorWrapper() {
@@ -168,6 +177,7 @@ public class ExecutorWrapper {
         ExecutorWrapper executorWrapper = new ExecutorWrapper();
         BeanUtil.copyProperties(this, executorWrapper);
         executorWrapper.setExecutor(new CapturedExecutor(this.getExecutor()));
+        executorWrapper.setThreadPoolStatProvider(ThreadPoolStatProvider.of(executorWrapper));
         return executorWrapper;
     }
     /**

--- a/core/src/main/java/org/dromara/dynamictp/core/timer/QueueTimeoutTimerTask.java
+++ b/core/src/main/java/org/dromara/dynamictp/core/timer/QueueTimeoutTimerTask.java
@@ -17,7 +17,6 @@
 
 package org.dromara.dynamictp.core.timer;
 
-import cn.hutool.core.text.CharSequenceUtil;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.dromara.dynamictp.core.notifier.manager.AlarmManager;
@@ -45,10 +44,10 @@ public class QueueTimeoutTimerTask extends AbstractTimeoutTimerTask {
         val pair = getTaskNameAndTraceId();
         statProvider.incQueueTimeoutCount(1);
         AlarmManager.tryAlarmAsync(executorWrapper, QUEUE_TIMEOUT, runnable);
-        String logMsg = CharSequenceUtil.format("DynamicTp execute, queue timeout, " +
-                        "tpName: {}, taskName: {}, traceId: {}, queueTimeout: {}ms, " +
-                        "poolSize: {} (active: {}, core: {}, max: {}, largest: {}), " +
-                        "queueCapacity: {} (currSize: {}, remaining: {})",
+        String logMsg = String.format("DynamicTp execute, queue timeout, " +
+                        "tpName: %s, taskName: %s, traceId: %s, queueTimeout: %sms, " +
+                        "poolSize: %s (active: %s, core: %s, max: %s, largest: %s), " +
+                        "queueCapacity: %s (currSize: %s, remaining: %s)",
                 statProvider.getExecutorWrapper().getThreadPoolName(), pair.getLeft(), pair.getRight(),
                 statProvider.getQueueTimeout(), executor.getPoolSize(), executor.getActiveCount(),
                 executor.getCorePoolSize(), executor.getMaximumPoolSize(),

--- a/core/src/main/java/org/dromara/dynamictp/core/timer/RunTimeoutTimerTask.java
+++ b/core/src/main/java/org/dromara/dynamictp/core/timer/RunTimeoutTimerTask.java
@@ -17,7 +17,6 @@
 
 package org.dromara.dynamictp.core.timer;
 
-import cn.hutool.core.text.CharSequenceUtil;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.dromara.dynamictp.core.notifier.manager.AlarmManager;
@@ -48,10 +47,10 @@ public class RunTimeoutTimerTask extends AbstractTimeoutTimerTask {
         val pair = getTaskNameAndTraceId();
         statProvider.incRunTimeoutCount(1);
         AlarmManager.tryAlarmAsync(executorWrapper, RUN_TIMEOUT, runnable);
-        String logMsg = CharSequenceUtil.format("DynamicTp execute, run timeout, " +
-                        "tpName: {}, taskName: {}, traceId: {}, runTimeout: {}ms, " +
-                        "poolSize: {} (active: {}, core: {}, max: {}, largest: {}), " +
-                        "queueCapacity: {} (currSize: {}, remaining: {}), stackTrace: {}",
+        String logMsg = String.format("DynamicTp execute, run timeout, " +
+                        "tpName: %s, taskName: %s, traceId: %s, runTimeout: %sms, " +
+                        "poolSize: %s (active: %s, core: %s, max: %s, largest: %s), " +
+                        "queueCapacity: %s (currSize: %s, remaining: %s), stackTrace: %s",
                 statProvider.getExecutorWrapper().getThreadPoolName(), pair.getLeft(), pair.getRight(),
                 statProvider.getRunTimeout(), executor.getPoolSize(), executor.getActiveCount(),
                 executor.getCorePoolSize(), executor.getMaximumPoolSize(), executor.getLargestPoolSize(),

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -20,11 +20,10 @@
         <logback.version>1.2.10</logback.version>
         <log4j.version>2.17.1</log4j.version>
 
-        <hutool.version>5.8.25</hutool.version>
         <guava.version>31.1-jre</guava.version>
         <jackson.version>2.13.5</jackson.version>
         <gson.version>2.8.9</gson.version>
-        <fastjson.version>1.2.83</fastjson.version>
+        <fastjson2.version>2.0.64</fastjson2.version>
 
         <ttl.version>2.14.5</ttl.version>
         <equator.version>1.0.4</equator.version>
@@ -110,18 +109,6 @@
                 <groupId>net.devh</groupId>
                 <artifactId>grpc-spring-boot-starter</artifactId>
                 <version>${grpc-starter.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>cn.hutool</groupId>
-                <artifactId>hutool-core</artifactId>
-                <version>${hutool.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>cn.hutool</groupId>
-                <artifactId>hutool-http</artifactId>
-                <version>${hutool.version}</version>
             </dependency>
 
             <dependency>
@@ -278,9 +265,9 @@
                 <version>${gson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.alibaba</groupId>
-                <artifactId>fastjson</artifactId>
-                <version>${fastjson.version}</version>
+                <groupId>com.alibaba.fastjson2</groupId>
+                <artifactId>fastjson2</artifactId>
+                <version>${fastjson2.version}</version>
             </dependency>
 
             <dependency>

--- a/docs/hutool-removal-plan.md
+++ b/docs/hutool-removal-plan.md
@@ -1,0 +1,465 @@
+# Hutool 剥离方案
+
+> 目标：将 dynamic-tp 项目对 `cn.hutool`（hutool-core 5.8.25 + hutool-http 5.8.25）的全部依赖移除，替换为 JDK 原生 API、项目已有依赖或少量自建工具方法。
+
+## 一、现状概览
+
+### 1.1 依赖声明位置
+
+| 文件 | 声明内容 |
+|------|----------|
+| [dependencies/pom.xml](../dependencies/pom.xml#L23) | `<hutool.version>5.8.25</hutool.version>` 版本属性 |
+| [dependencies/pom.xml](../dependencies/pom.xml#L115-L125) | `dependencyManagement` 中管理 `hutool-core` 和 `hutool-http` |
+| [common/pom.xml](../common/pom.xml#L49-L52) | `common` 模块直接依赖 `hutool-http` |
+| [core/pom.xml](../core/pom.xml#L40-L43) | `core` 模块直接依赖 `hutool-core` |
+
+### 1.2 使用统计
+
+- **主代码**：13 个文件，涉及 6 类 Hutool API
+- **测试代码**：6 个文件，涉及 4 类 Hutool API
+- **共计**：19 个文件
+
+### 1.3 项目约束
+
+- **Java 版本：Java 8**（`maven.compiler.source/target = 8`），**不能使用** `java.net.http.HttpClient`（Java 11+）
+- `common` 模块和 `core` 模块**未直接依赖 Spring**，设计上保持轻量解耦，替换方案应避免向这两个模块引入 Spring 依赖
+
+### 1.4 可用已有库
+
+以下库已在项目依赖中，替代方案**优先复用**，避免重复造轮子：
+
+| 库 | 坐标 | 本方案用到的 API |
+|----|------|-----------------|
+| **Apache Commons Lang3** | `org.apache.commons:commons-lang3` | `ArrayUtils.isNotEmpty()`、`FieldUtils`（支撑自建 BeanUtil）、已有 `ReflectionUtil` |
+| **Guava** | `com.google.guava:guava` | `Sets.newHashSet()`（测试）、`Files.asCharSource().read()`（测试可选） |
+| **Apache Commons Collections4** | `org.apache.commons:commons-collections4` | `CollectionUtils`（已有使用） |
+| **commons-codec** | `commons-codec:commons-codec` | 已有的 `Base64` 等编解码（LarkNotifier 已用） |
+| **Lombok** | `org.projectlombok:lombok` | `@Slf4j`、`val` 等（已有使用） |
+
+---
+
+## 二、Hutool API 使用清单与替代方案
+
+### 2.1 主代码（src/main）
+
+#### ① `CharSequenceUtil.format()` — `{}` 占位符字符串格式化（3 处）
+
+| 文件 | 行号 | 用法 |
+|------|------|------|
+| [RunTimeoutTimerTask.java](../core/src/main/java/org/dromara/dynamictp/core/timer/RunTimeoutTimerTask.java#L51) | 51 | `CharSequenceUtil.format("... {}, ...", args)` |
+| [QueueTimeoutTimerTask.java](../core/src/main/java/org/dromara/dynamictp/core/timer/QueueTimeoutTimerTask.java#L48) | 48 | 同上 |
+| [TaskRejectAware.java](../core/src/main/java/org/dromara/dynamictp/core/aware/TaskRejectAware.java#L62) | 62 | 同上 |
+
+**替代方案**：在 `common` 模块新建 `StrUtil.format()` 自实现 `{}` 占位符替换
+
+> ~~SLF4J 的 `MessageFormatter`~~ **不适用**——其对最后一个参数为 `Throwable` 时有特殊处理（不替换 `{}` 而提取为异常），且对 `\{}` 有转义语义，与 Hutool 的 `CharSequenceUtil.format()` 行为不完全一致。自建极简方法可保证行为完全等价，零依赖。
+
+```java
+// Before
+String logMsg = CharSequenceUtil.format("tpName: {}, taskName: {}", name, taskName);
+
+// After
+import org.dromara.dynamictp.common.util.StrUtil;
+String logMsg = StrUtil.format("tpName: {}, taskName: {}", name, taskName);
+```
+
+```java
+// common/src/main/java/org/dromara/dynamictp/common/util/StrUtil.java
+public final class StrUtil {
+
+    private static final String PLACEHOLDER = "{}";
+
+    private StrUtil() {}
+
+    /**
+     * 使用 {} 占位符格式化字符串，行为与 Hutool CharSequenceUtil.format 完全一致。
+     */
+    public static String format(String template, Object... args) {
+        if (template == null || template.isEmpty()) {
+            return template;
+        }
+        if (args == null || args.length == 0) {
+            return template;
+        }
+        StringBuilder sb = new StringBuilder(template.length() + 50);
+        int argIndex = 0;
+        int i = 0;
+        while (i < template.length()) {
+            if (i < template.length() - 1
+                    && template.charAt(i) == '{'
+                    && template.charAt(i + 1) == '}') {
+                if (argIndex < args.length) {
+                    sb.append(args[argIndex++]);
+                } else {
+                    sb.append(PLACEHOLDER);
+                }
+                i += 2;
+            } else {
+                sb.append(template.charAt(i));
+                i++;
+            }
+        }
+        return sb.toString();
+    }
+}
+```
+
+---
+
+#### ② `BeanUtil.copyProperties()` — Bean 属性拷贝（4 处）
+
+| 文件 | 行号 | 拷贝对象 |
+|------|------|----------|
+| [ExecutorWrapper.java](../core/src/main/java/org/dromara/dynamictp/core/support/ExecutorWrapper.java#L169) | 169 | `ExecutorWrapper` → `ExecutorWrapper` |
+| [AbstractDtpNotifier.java](../core/src/main/java/org/dromara/dynamictp/core/notifier/AbstractDtpNotifier.java#L187) | 187 | `NotifyPlatform` → `NotifyPlatform` |
+| [MicroMeterCollector.java](../core/src/main/java/org/dromara/dynamictp/core/monitor/collector/MicroMeterCollector.java#L65) | 65 | `ThreadPoolStats` → `ThreadPoolStats` |
+| [JMXCollector.java](../core/src/main/java/org/dromara/dynamictp/core/monitor/collector/jmx/JMXCollector.java#L52) | 52 | `ThreadPoolStats` → `ThreadPoolStats` |
+
+**替代方案**：在 `common` 模块新建 `BeanUtil` 工具类，基于反射实现简单属性拷贝
+
+> 由于 `common`/`core` 模块无 Spring 依赖，不宜使用 `org.springframework.beans.BeanUtils`。四个场景均为**同类型**对象拷贝，简单的反射实现完全够用。项目已有 `ReflectionUtil`（基于 Apache Commons Lang3 `FieldUtils`），可复用其底层。
+
+```java
+// common/src/main/java/org/dromara/dynamictp/common/util/BeanUtil.java
+public final class BeanUtil {
+    private BeanUtil() {}
+
+    public static void copyProperties(Object source, Object target) {
+        Objects.requireNonNull(source, "source must not be null");
+        Objects.requireNonNull(target, "target must not be null");
+        for (Field field : FieldUtils.getAllFieldsList(source.getClass())) {
+            try {
+                Object value = FieldUtils.readField(field, source, true);
+                Field targetField = FieldUtils.getField(target.getClass(), field.getName(), true);
+                if (targetField != null) {
+                    FieldUtils.writeField(targetField, target, value, true);
+                }
+            } catch (IllegalAccessException e) {
+                // skip unreadable/unwritable field
+            }
+        }
+    }
+}
+```
+
+---
+
+#### ③ `NumberUtil.div()` — 除法保留小数（1 文件，2 处）
+
+| 文件 | 行号 | 用法 |
+|------|------|------|
+| [AlarmManager.java](../core/src/main/java/org/dromara/dynamictp/core/notifier/manager/AlarmManager.java#L160) | 160 | `NumberUtil.div(activeCount, maxPoolSize, 2) * 100` |
+| [AlarmManager.java](../core/src/main/java/org/dromara/dynamictp/core/notifier/manager/AlarmManager.java#L174) | 174 | `NumberUtil.div(queueSize, queueCapacity, 2) * 100` |
+
+**替代方案**：`BigDecimal` 除法
+
+```java
+// Before
+double div = NumberUtil.div(executor.getActiveCount(), maximumPoolSize, 2) * 100;
+
+// After
+double div = BigDecimal.valueOf(executor.getActiveCount())
+        .divide(BigDecimal.valueOf(maximumPoolSize), 2, RoundingMode.HALF_UP)
+        .doubleValue() * 100;
+```
+
+---
+
+#### ④ `UrlBuilder` — URL 构建与查询参数操作（4 处）
+
+| 文件 | 用法 |
+|------|------|
+| [DingNotifier.java](../common/src/main/java/org/dromara/dynamictp/common/notifier/DingNotifier.java#L90) | `UrlBuilder.of(webhook)` → `addQuery()` → `build()` |
+| [LarkNotifier.java](../common/src/main/java/org/dromara/dynamictp/common/notifier/LarkNotifier.java#L103) | `UrlBuilder.of()` → `getPath().getSegments()` → `addPath()` → `build()` |
+| [WechatNotifier.java](../common/src/main/java/org/dromara/dynamictp/common/notifier/WechatNotifier.java#L60) | `UrlBuilder.of()` → `getQuery().get()` → `addQuery()` → `build()` |
+| [YunZhiJiaNotifier.java](../extension/extension-notify-yunzhijia/src/main/java/org/dromara/dynamictp/extension/notify/yunzhijia/YunZhiJiaNotifier.java#L58) | 同 Wechat 模式 |
+
+**替代方案**：在 `common` 模块新建轻量 `UrlBuilder` 工具类
+
+> 使用 JDK `java.net.URI` / `java.net.URL` 解析，`StringBuilder` 拼接查询参数，覆盖当前所有使用场景（addQuery、getQuery、getPath segments、addPath）。
+
+```java
+// common/src/main/java/org/dromara/dynamictp/common/util/UrlBuilder.java
+public class UrlBuilder {
+    private final String base;
+    private final Map<String, String> queryParams = new LinkedHashMap<>();
+    private final List<String> pathSegments = new ArrayList<>();
+
+    private UrlBuilder(String base) {
+        // 解析已有 query 和 path 到各自集合
+        this.base = base;
+    }
+
+    public static UrlBuilder of(String url) { return new UrlBuilder(url); }
+    public String getQuery(String key) { return queryParams.get(key); }
+    public UrlBuilder addQuery(String key, Object val) { queryParams.put(key, String.valueOf(val)); return this; }
+    public List<String> getPathSegments() { return pathSegments; }
+    public UrlBuilder addPath(String segment) { pathSegments.add(segment); return this; }
+    public String build() { /* 拼装最终 URL */ }
+}
+```
+
+---
+
+#### ⑤ `HttpRequest` / `HttpResponse` — HTTP POST（1 处，核心改动）
+
+| 文件 | 行号 | 用法 |
+|------|------|------|
+| [AbstractHttpNotifier.java](../common/src/main/java/org/dromara/dynamictp/common/notifier/AbstractHttpNotifier.java#L43-L54) | 43-54 | `HttpRequest.post(url).setConnectionTimeout(t).setReadTimeout(t).body(msgBody).setProxy(...).execute()` |
+
+**替代方案**：JDK 原生 `HttpURLConnection`（零新增依赖）
+
+> 当前 HTTP 调用非常简单——仅 POST JSON + 超时 + 代理，没有连接池、拦截器、异步、文件上传等复杂能力。`HttpURLConnection` 完全胜任，无需引入任何第三方 HTTP 客户端，符合"减少第三方依赖"的剥离目标。
+
+```java
+// AbstractHttpNotifier.send0() 改写
+@Override
+protected void send0(NotifyPlatform platform, String content) {
+    String url = buildUrl(platform);
+    String msgBody = buildMsgBody(platform, content);
+
+    try {
+        URL targetUrl = new URL(url);
+        Proxy proxy = platform.getProxyType() != Proxy.Type.DIRECT
+                ? new Proxy(platform.getProxyType(), new InetSocketAddress(platform.getProxyHost(), platform.getProxyPort()))
+                : Proxy.NO_PROXY;
+
+        HttpURLConnection conn = (HttpURLConnection) targetUrl.openConnection(proxy);
+        conn.setRequestMethod("POST");
+        conn.setConnectTimeout(platform.getTimeout());
+        conn.setReadTimeout(platform.getTimeout());
+        conn.setDoOutput(true);
+        conn.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(msgBody.getBytes(StandardCharsets.UTF_8));
+        }
+
+        int code = conn.getResponseCode();
+        String respBody = readBody(conn, code);
+        log.info("DynamicTp notify, {} send success, response: {}, request: {}",
+                platform(), respBody, msgBody);
+    } catch (IOException e) {
+        log.error("DynamicTp notify, {} send failed, request: {}", platform(), msgBody, e);
+    }
+}
+
+private String readBody(HttpURLConnection conn, int code) throws IOException {
+    InputStream is = (code >= 200 && code < 400) ? conn.getInputStream() : conn.getErrorStream();
+    if (is == null) {
+        return "";
+    }
+    try (InputStream in = is) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = in.read(buffer)) != -1) {
+            baos.write(buffer, 0, len);
+        }
+        return baos.toString(StandardCharsets.UTF_8.name());
+    }
+}
+```
+
+---
+
+#### ⑥ `ReflectUtil` — 反射获取/设置字段（1 文件，多处）
+
+| 文件 | 行号 | 用法 |
+|------|------|------|
+| [DtpPropertiesBinderUtil.java](../common/src/main/java/org/dromara/dynamictp/common/util/DtpPropertiesBinderUtil.java#L92) | 92 | `ReflectUtil.getFieldValue(dtpProperties, field)` |
+| 同上 | 149 | `ReflectUtil.setFieldValue(executor, fieldName, value)` |
+| 同上 | 155,159,163,167,172 | 多处 `ReflectUtil.setFieldValue(...)` |
+
+**替代方案**：**直接使用项目已有的 `ReflectionUtil`**（[common/.../ReflectionUtil.java](../common/src/main/java/org/dromara/dynamictp/common/util/ReflectionUtil.java)）
+
+> 项目已封装了 `ReflectionUtil`，基于 Apache Commons Lang3 `FieldUtils`，提供了 `getFieldValue(fieldName, obj)` 和 `setFieldValue(fieldName, obj, val)` 方法。Hutool 的 `ReflectUtil.getFieldValue(obj, field)` 和 `ReflectUtil.setFieldValue(obj, fieldName, value)` 参数顺序不同，需注意调整。
+
+```java
+// Before
+ReflectUtil.getFieldValue(dtpProperties, dtpPropertiesField)
+ReflectUtil.setFieldValue(executor, field.getName(), globalFieldVal)
+
+// After — 参数顺序：fieldName 在前，obj 在后
+ReflectionUtil.getFieldValue(dtpPropertiesField.getName(), dtpProperties)
+ReflectionUtil.setFieldValue(field.getName(), executor, globalFieldVal)
+```
+
+---
+
+#### ⑦ `CollUtil.contains()` / `ArrayUtil.isNotEmpty()` — 集合/数组工具（1 文件，2 处）
+
+| 文件 | 行号 | 用法 |
+|------|------|------|
+| [AgentAware.java](../extension/extension-agent/src/main/java/org/dromara/dynamictp/extension/agent/AgentAware.java#L75) | 75 | `CollUtil.contains(visitedClass, o.getClass())` |
+| [AgentAware.java](../extension/extension-agent/src/main/java/org/dromara/dynamictp/extension/agent/AgentAware.java#L92) | 92 | `ArrayUtil.isNotEmpty(declaredFields)` |
+
+**替代方案**：JDK 原生 + Apache Commons（已有）
+
+```java
+// CollUtil.contains → Collection.contains (或 Apache Commons CollectionUtils.contains)
+visitedClass.contains(o.getClass())
+
+// ArrayUtil.isNotEmpty → Apache Commons ArrayUtils.isNotEmpty (已有依赖)
+import org.apache.commons.lang3.ArrayUtils;
+ArrayUtils.isNotEmpty(declaredFields)
+```
+
+---
+
+#### ⑧ `FileUtil.readableFileSize()` — 字节数转可读大小（1 处）
+
+| 文件 | 行号 | 用法 |
+|------|------|------|
+| [DtpEndpoint.java](../starter/starter-common/src/main/java/org/dromara/dynamictp/starter/common/monitor/DtpEndpoint.java#L60-L63) | 60-63 | `FileUtil.readableFileSize(runtime.maxMemory())` |
+
+**替代方案**：自建工具方法（`starter-common` 模块已有 Spring 依赖）
+
+```java
+private static String readableFileSize(long bytes) {
+    if (bytes < 1024) return bytes + " B";
+    int unitIndex = (int) (Math.log(bytes) / Math.log(1024));
+    String[] units = {"B", "KB", "MB", "GB", "TB"};
+    double value = bytes / Math.pow(1024, unitIndex);
+    return String.format("%.2f %s", value, units[unitIndex]);
+}
+```
+
+> 也可放入 `common` 模块的 `FileSizeUtil` 中统一管理。
+
+---
+
+### 2.2 测试代码（src/test）
+
+| 文件 | Hutool API | 替代方案 |
+|------|------------|----------|
+| [InterceptTest.java](../test/test-core/src/test/java/org/dromara/dynamictp/test/core/plugin/InterceptTest.java#L58) | `CollectionUtil.newHashSet("TestAInterceptor")` | **Guava** `Sets.newHashSet("TestAInterceptor")` |
+| [YamlConfigParserTest.java](../test/test-core/src/test/java/org/dromara/dynamictp/test/core/parse/YamlConfigParserTest.java#L46) | `FileUtil.readString(file, charset)` | JDK `new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8)` |
+| [PropertiesConfigParserTest.java](../test/test-core/src/test/java/org/dromara/dynamictp/test/core/parse/PropertiesConfigParserTest.java#L46) | 同上 | 同上 |
+| [JsonConfigParserTest.java](../test/test-core/src/test/java/org/dromara/dynamictp/test/core/parse/JsonConfigParserTest.java#L46) | 同上 | 同上 |
+| [DtpWechatNotifierTest.java](../test/test-core/src/test/java/org/dromara/dynamictp/test/core/notify/DtpWechatNotifierTest.java#L20-L21) | `HttpRequest`, `HttpResponse`（import 但**未使用**） | 直接删除 import |
+| [BeanCopierUtilTest.java](../test/test-common/src/test/java/org/dromara/dynamictp/test/common/util/BeanCopierUtilTest.java#L51) | `BeanUtil.copyProperties(src, target)` | 使用项目新建的 `BeanUtil.copyProperties()`（基于 **commons-lang3** `FieldUtils`） |
+
+---
+
+## 三、实施计划
+
+### Phase 1：新建替代工具类（无破坏性变更）
+
+| 步骤 | 模块 | 内容 |
+|------|------|------|
+| 1.1 | `common` | 新建 `StrUtil.java` — 自实现 `{}` 占位符格式化（无已有库可替代） |
+| 1.2 | `common` | 新建 `BeanUtil.java` — 基于 **commons-lang3** `FieldUtils` 的属性拷贝 |
+| 1.3 | `common` | 新建 `UrlBuilder.java` — 轻量 URL 构建器（无已有库可替代） |
+| 1.4 | `common` | 新建 `FileSizeUtil.java`（可选）— 字节数转可读字符串 |
+
+### Phase 2：替换主代码引用
+
+按依赖关系由底向上替换，每个模块替换后编译验证：
+
+| 步骤 | 模块 | 文件 | 替换内容 |
+|------|------|------|----------|
+| 2.1 | `common` | DtpPropertiesBinderUtil.java | `ReflectUtil` → 项目已有 `ReflectionUtil` |
+| 2.2 | `common` | DingNotifier, LarkNotifier, WechatNotifier | `UrlBuilder` → 项目新建 `UrlBuilder` |
+| 2.3 | `common` | AbstractHttpNotifier.java | `HttpRequest/HttpResponse` → `HttpURLConnection` |
+| 2.4 | `common/pom.xml` | — | 移除 `hutool-http` 依赖（**无需新增依赖**） |
+| 2.5 | `core` | RunTimeoutTimerTask, QueueTimeoutTimerTask, TaskRejectAware | `CharSequenceUtil` → `StrUtil` |
+| 2.6 | `core` | AlarmManager.java | `NumberUtil.div` → `BigDecimal` |
+| 2.7 | `core` | ExecutorWrapper, AbstractDtpNotifier, MicroMeterCollector, JMXCollector | `BeanUtil` → 项目新建 `BeanUtil` |
+| 2.8 | `core/pom.xml` | — | 移除 `hutool-core` 依赖 |
+| 2.9 | `extension-agent` | AgentAware.java | `CollUtil.contains` → `contains()`，`ArrayUtil.isNotEmpty` → `ArrayUtils.isNotEmpty` |
+| 2.10 | `extension-notify-yunzhijia` | YunZhiJiaNotifier.java | `UrlBuilder` → 项目新建 `UrlBuilder` |
+| 2.11 | `starter-common` | DtpEndpoint.java | `FileUtil.readableFileSize` → 自建方法 |
+
+### Phase 3：替换测试代码引用
+
+| 步骤 | 文件 | 替换内容 |
+|------|------|----------|
+| 3.1 | InterceptTest.java | `CollectionUtil.newHashSet` → **Guava** `Sets.newHashSet` |
+| 3.2 | YamlConfigParserTest.java | `FileUtil.readString` → `Files.readAllBytes` |
+| 3.3 | PropertiesConfigParserTest.java | 同上 |
+| 3.4 | JsonConfigParserTest.java | 同上 |
+| 3.5 | DtpWechatNotifierTest.java | 删除未使用的 import |
+| 3.6 | BeanCopierUtilTest.java | `BeanUtil.copyProperties` → 项目新建 `BeanUtil` |
+
+### Phase 4：清理依赖
+
+| 步骤 | 文件 | 内容 |
+|------|------|------|
+| 4.1 | [dependencies/pom.xml](../dependencies/pom.xml) | 移除 `<hutool.version>` 属性 |
+| 4.2 | [dependencies/pom.xml](../dependencies/pom.xml) | 移除 `dependencyManagement` 中 `hutool-core` 和 `hutool-http` |
+| 4.3 | — | **无需新增依赖**（HTTP 改用 JDK 原生 `HttpURLConnection`） |
+| 4.4 | 全局 | `grep -r "hutool"` 确认无残留引用 |
+
+### Phase 5：验证
+
+- [ ] `mvn clean compile -pl common,core,extension/extension-agent,extension/extension-notify-yunzhijia,starter/starter-common` 编译通过
+- [ ] `mvn test` 全部测试通过
+- [ ] `grep -r "cn.hutool"` 返回空
+- [ ] 检查无 `hutool` 的传递依赖：`mvn dependency:tree | grep hutool`
+
+---
+
+## 四、风险评估
+
+| 风险点 | 等级 | 说明 | 缓解措施 |
+|--------|------|------|----------|
+| `HttpURLConnection` 替换 HTTP 行为差异 | **低** | hutool-http 默认不抛异常，`HttpURLConnection` 对 4xx/5xx 需读取 `getErrorStream()` | `readBody()` 方法已按状态码分流处理；需确认日志输出格式不变 |
+| `BeanUtil.copyProperties` 行为差异 | **中** | Hutool 版支持类型转换、忽略 null 等选项 | 当前 4 处使用均为同类型简单属性拷贝、未使用 CopyOptions，简单反射实现完全等价 |
+| `UrlBuilder` 边界场景 | **低** | URL 编码、特殊字符处理 | 现有 webhook URL 结构简单，测试用例覆盖正常场景即可 |
+| `ReflectionUtil` 参数顺序 | **低** | Hutool `ReflectUtil.getFieldValue(obj, field)` vs 项目 `ReflectionUtil.getFieldValue(fieldName, obj)` | 逐处替换时仔细调整参数顺序，编译器会捕获类型不匹配 |
+| `NumberUtil.div` 除零保护 | **低** | Hutool 的 div 有除零保护（返回 0） | AlarmManager 中 `maximumPoolSize` 和 `queueCapacity` 不会为 0；如有顾虑加 `if (divisor == 0) return 0;` |
+
+---
+
+## 五、新增工具类清单
+
+| 类名 | 模块 | 位置 | 替代 API |
+|------|------|------|----------|
+| `StrUtil` | common | `common/src/main/java/org/dromara/dynamictp/common/util/StrUtil.java` | `CharSequenceUtil.format` |
+| `BeanUtil` | common | `common/src/main/java/org/dromara/dynamictp/common/util/BeanUtil.java` | `cn.hutool.core.bean.BeanUtil` |
+| `UrlBuilder` | common | `common/src/main/java/org/dromara/dynamictp/common/util/UrlBuilder.java` | `cn.hutool.core.net.url.UrlBuilder` |
+| `FileSizeUtil`（可选） | common | `common/src/main/java/org/dromara/dynamictp/common/util/FileSizeUtil.java` | `cn.hutool.core.io.FileUtil.readableFileSize` |
+
+> 以上工具类均放在 `common` 模块的 `org.dromara.dynamictp.common.util` 包下，与已有的 `ReflectionUtil`、`JsonUtil` 等保持一致。
+
+---
+
+## 六、依赖变更汇总
+
+### 移除
+
+```xml
+<!-- dependencies/pom.xml -->
+<dependency>
+    <groupId>cn.hutool</groupId>
+    <artifactId>hutool-core</artifactId>
+    <version>${hutool.version}</version>   <!-- 移除 -->
+</dependency>
+<dependency>
+    <groupId>cn.hutool</groupId>
+    <artifactId>hutool-http</artifactId>
+    <version>${hutool.version}</version>   <!-- 移除 -->
+</dependency>
+<!-- 同时移除 <hutool.version>5.8.25</hutool.version> 属性 -->
+```
+
+```xml
+<!-- common/pom.xml -->
+<dependency>
+    <groupId>cn.hutool</groupId>
+    <artifactId>hutool-http</artifactId>   <!-- 移除 -->
+</dependency>
+```
+
+```xml
+<!-- core/pom.xml -->
+<dependency>
+    <groupId>cn.hutool</groupId>
+    <artifactId>hutool-core</artifactId>   <!-- 移除 -->
+</dependency>
+```
+
+### 新增
+
+**无需新增任何依赖**——HTTP 调用改用 JDK 原生 `HttpURLConnection`，其余功能由已有的 SLF4J、Apache Commons Lang3 等依赖覆盖。

--- a/extension/extension-agent/src/main/java/org/dromara/dynamictp/extension/agent/AgentAware.java
+++ b/extension/extension-agent/src/main/java/org/dromara/dynamictp/extension/agent/AgentAware.java
@@ -17,8 +17,6 @@
 
 package org.dromara.dynamictp.extension.agent;
 
-import cn.hutool.core.collection.CollUtil;
-import cn.hutool.core.util.ArrayUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.dromara.dynamictp.core.aware.TaskStatAware;
@@ -35,6 +33,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.ArrayUtils;
 
 import static org.dromara.dynamictp.common.constant.DynamicTpConst.DTP_EXECUTE_ENHANCED;
 import static org.dromara.dynamictp.common.constant.DynamicTpConst.FALSE_STR;
@@ -72,7 +71,7 @@ public class AgentAware extends TaskStatAware {
             if (o instanceof DtpRunnable) {
                 return (DtpRunnable) o;
             }
-            if (Objects.isNull(o) || CollUtil.contains(visitedClass, o.getClass())) {
+            if (Objects.isNull(o) || visitedClass.contains(o.getClass())) {
                 return null;
             } else {
                 visitedClass.add(o.getClass());
@@ -89,7 +88,7 @@ public class AgentAware extends TaskStatAware {
     private DtpRunnable getDtpRunnable(Class<? extends Runnable> rClass, Runnable r, Set<Class> visitedClass) throws IllegalAccessException {
         while (Runnable.class.isAssignableFrom(rClass)) {
             Field[] declaredFields = rClass.getDeclaredFields();
-            if (ArrayUtil.isNotEmpty(declaredFields)) {
+            if (ArrayUtils.isNotEmpty(declaredFields)) {
                 List<Field> conditionFields = Arrays.stream(declaredFields)
                         .filter(ele -> Runnable.class.isAssignableFrom(ele.getType()))
                         .collect(Collectors.toList());

--- a/extension/extension-notify-yunzhijia/src/main/java/org/dromara/dynamictp/extension/notify/yunzhijia/YunZhiJiaNotifier.java
+++ b/extension/extension-notify-yunzhijia/src/main/java/org/dromara/dynamictp/extension/notify/yunzhijia/YunZhiJiaNotifier.java
@@ -17,12 +17,12 @@
 
 package org.dromara.dynamictp.extension.notify.yunzhijia;
 
-import cn.hutool.core.net.url.UrlBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.dromara.dynamictp.common.entity.NotifyPlatform;
 import org.dromara.dynamictp.common.notifier.AbstractHttpNotifier;
 import org.dromara.dynamictp.common.util.JsonUtil;
+import org.dromara.dynamictp.common.util.UrlBuilder;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -56,10 +56,10 @@ public class YunZhiJiaNotifier extends AbstractHttpNotifier {
             return platform.getWebhook();
         }
         UrlBuilder builder = UrlBuilder.of(Optional.ofNullable(platform.getWebhook()).orElse(YunZhiJiaNotifyConst.WEB_HOOK));
-        if (StringUtils.isBlank(builder.getQuery().get(YunZhiJiaNotifyConst.YZJ_TYPE_PARAM))) {
+        if (StringUtils.isBlank(builder.getQueryParam(YunZhiJiaNotifyConst.YZJ_TYPE_PARAM))) {
             builder.addQuery(YunZhiJiaNotifyConst.YZJ_TYPE_PARAM, 0);
         }
-        if (StringUtils.isBlank(builder.getQuery().get(YunZhiJiaNotifyConst.YZJ_TOKEN_PARAM))) {
+        if (StringUtils.isBlank(builder.getQueryParam(YunZhiJiaNotifyConst.YZJ_TOKEN_PARAM))) {
             builder.addQuery(YunZhiJiaNotifyConst.YZJ_TOKEN_PARAM, platform.getUrlKey());
         }
         return builder.build();

--- a/starter/starter-common/src/main/java/org/dromara/dynamictp/starter/common/monitor/DtpEndpoint.java
+++ b/starter/starter-common/src/main/java/org/dromara/dynamictp/starter/common/monitor/DtpEndpoint.java
@@ -17,7 +17,6 @@
 
 package org.dromara.dynamictp.starter.common.monitor;
 
-import cn.hutool.core.io.FileUtil;
 import com.google.common.collect.Lists;
 import lombok.val;
 import org.apache.commons.collections4.MapUtils;
@@ -31,6 +30,7 @@ import org.dromara.dynamictp.core.aware.MetricsAware;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 
+import java.text.DecimalFormat;
 import java.util.List;
 
 /**
@@ -57,11 +57,28 @@ public class DtpEndpoint {
         }
         JvmStats jvmStats = new JvmStats();
         Runtime runtime = Runtime.getRuntime();
-        jvmStats.setMaxMemory(FileUtil.readableFileSize(runtime.maxMemory()));
-        jvmStats.setTotalMemory(FileUtil.readableFileSize(runtime.totalMemory()));
-        jvmStats.setFreeMemory(FileUtil.readableFileSize(runtime.freeMemory()));
-        jvmStats.setUsableMemory(FileUtil.readableFileSize(runtime.maxMemory() - runtime.totalMemory() + runtime.freeMemory()));
+        jvmStats.setMaxMemory(readableFileSize(runtime.maxMemory()));
+        jvmStats.setTotalMemory(readableFileSize(runtime.totalMemory()));
+        jvmStats.setFreeMemory(readableFileSize(runtime.freeMemory()));
+        jvmStats.setUsableMemory(readableFileSize(runtime.maxMemory() - runtime.totalMemory() + runtime.freeMemory()));
         metricsList.add(jvmStats);
         return metricsList;
+    }
+
+    private static final String[] SIZE_UNITS = {"B", "KB", "MB", "GB", "TB", "PB", "EB"};
+
+    /**
+     * 可读的文件大小表示，参考 hutool DataSizeUtil.format 方法。
+     *
+     * @param size 字节数
+     * @return 可读的大小字符串，如 "1.5 GB"
+     */
+    private static String readableFileSize(long size) {
+        if (size <= 0) {
+            return "0";
+        }
+        int digitGroups = Math.min(SIZE_UNITS.length - 1, (int) (Math.log10(size) / Math.log10(1024)));
+        return new DecimalFormat("#,##0.##")
+                .format(size / Math.pow(1024, digitGroups)) + " " + SIZE_UNITS[digitGroups];
     }
 }

--- a/test/test-common/pom.xml
+++ b/test/test-common/pom.xml
@@ -51,8 +51,8 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>fastjson</artifactId>
+            <groupId>com.alibaba.fastjson2</groupId>
+            <artifactId>fastjson2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.dromara.dynamictp</groupId>

--- a/test/test-common/src/test/java/org/dromara/dynamictp/test/common/util/BeanCopierUtilTest.java
+++ b/test/test-common/src/test/java/org/dromara/dynamictp/test/common/util/BeanCopierUtilTest.java
@@ -17,7 +17,7 @@
 
 package org.dromara.dynamictp.test.common.util;
 
-import cn.hutool.core.bean.BeanUtil;
+import org.dromara.dynamictp.common.util.BeanUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/test/test-core/src/test/java/org/dromara/dynamictp/test/core/notify/DtpWechatNotifierTest.java
+++ b/test/test-core/src/test/java/org/dromara/dynamictp/test/core/notify/DtpWechatNotifierTest.java
@@ -17,9 +17,6 @@
 
 package org.dromara.dynamictp.test.core.notify;
 
-import cn.hutool.http.HttpRequest;
-import cn.hutool.http.HttpResponse;
-import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.dromara.dynamictp.common.constant.WechatNotifyConst;
 import org.dromara.dynamictp.common.entity.MarkdownReq;

--- a/test/test-core/src/test/java/org/dromara/dynamictp/test/core/parse/JsonConfigParserTest.java
+++ b/test/test-core/src/test/java/org/dromara/dynamictp/test/core/parse/JsonConfigParserTest.java
@@ -17,7 +17,6 @@
 
 package org.dromara.dynamictp.test.core.parse;
 
-import cn.hutool.core.io.FileUtil;
 import org.dromara.dynamictp.common.em.ConfigFileTypeEnum;
 import org.dromara.dynamictp.common.parser.config.JsonConfigParser;
 import org.junit.jupiter.api.Test;
@@ -30,6 +29,7 @@ import org.springframework.util.ResourceUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Map;
 
 /**
@@ -43,7 +43,7 @@ public class JsonConfigParserTest {
     @Test
     void testDoParse() throws IOException {
         File file = ResourceUtils.getFile("classpath:demo-dtp-dev.json");
-        String content = FileUtil.readString(file, StandardCharsets.UTF_8);
+        String content = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
 
         JsonConfigParser parser = new JsonConfigParser();
         Map<Object, Object> result = parser.doParse(content);
@@ -53,7 +53,7 @@ public class JsonConfigParserTest {
     @Test
     void testDoParseMultipleFields() throws IOException {
         File file = ResourceUtils.getFile("classpath:demo-dtp-dev.json");
-        String content = FileUtil.readString(file, StandardCharsets.UTF_8);
+        String content = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
 
         JsonConfigParser parser = new JsonConfigParser();
         Map<Object, Object> result = parser.doParse(content);

--- a/test/test-core/src/test/java/org/dromara/dynamictp/test/core/parse/PropertiesConfigParserTest.java
+++ b/test/test-core/src/test/java/org/dromara/dynamictp/test/core/parse/PropertiesConfigParserTest.java
@@ -17,7 +17,6 @@
 
 package org.dromara.dynamictp.test.core.parse;
 
-import cn.hutool.core.io.FileUtil;
 import org.dromara.dynamictp.common.em.ConfigFileTypeEnum;
 import org.dromara.dynamictp.common.parser.config.PropertiesConfigParser;
 import org.junit.jupiter.api.Test;
@@ -30,6 +29,7 @@ import org.springframework.util.ResourceUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Map;
 
 /**
@@ -43,7 +43,7 @@ public class PropertiesConfigParserTest {
     @Test
     void testDoParse() throws IOException {
         File file = ResourceUtils.getFile("classpath:demo-dtp-dev.properties");
-        String content = FileUtil.readString(file, StandardCharsets.UTF_8);
+        String content = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
 
         PropertiesConfigParser parser = new PropertiesConfigParser();
         Map<Object, Object> result = parser.doParse(content);
@@ -53,7 +53,7 @@ public class PropertiesConfigParserTest {
     @Test
     void testDoParseMultipleFields() throws IOException {
         File file = ResourceUtils.getFile("classpath:demo-dtp-dev.properties");
-        String content = FileUtil.readString(file, StandardCharsets.UTF_8);
+        String content = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
 
         PropertiesConfigParser parser = new PropertiesConfigParser();
         Map<Object, Object> result = parser.doParse(content);

--- a/test/test-core/src/test/java/org/dromara/dynamictp/test/core/parse/YamlConfigParserTest.java
+++ b/test/test-core/src/test/java/org/dromara/dynamictp/test/core/parse/YamlConfigParserTest.java
@@ -17,7 +17,6 @@
 
 package org.dromara.dynamictp.test.core.parse;
 
-import cn.hutool.core.io.FileUtil;
 import org.dromara.dynamictp.common.em.ConfigFileTypeEnum;
 import org.dromara.dynamictp.common.parser.config.YamlConfigParser;
 import org.junit.jupiter.api.Test;
@@ -28,8 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.springframework.util.ResourceUtils;
 
 import java.io.File;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Map;
 
 /**
@@ -41,9 +41,9 @@ import java.util.Map;
 class YamlConfigParserTest {
 
     @Test
-    void testDoParse() throws FileNotFoundException {
+    void testDoParse() throws IOException {
         File file = ResourceUtils.getFile("classpath:demo-dtp-dev.yml");
-        String content = FileUtil.readString(file, StandardCharsets.UTF_8);
+        String content = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
 
         YamlConfigParser parser = new YamlConfigParser();
         Map<Object, Object> result = parser.doParse(content);
@@ -52,9 +52,9 @@ class YamlConfigParserTest {
     }
 
     @Test
-    void testDoParseMultipleFields() throws FileNotFoundException {
+    void testDoParseMultipleFields() throws IOException {
         File file = ResourceUtils.getFile("classpath:demo-dtp-dev.yml");
-        String content = FileUtil.readString(file, StandardCharsets.UTF_8);
+        String content = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
 
         YamlConfigParser parser = new YamlConfigParser();
         Map<Object, Object> result = parser.doParse(content);

--- a/test/test-core/src/test/java/org/dromara/dynamictp/test/core/plugin/InterceptTest.java
+++ b/test/test-core/src/test/java/org/dromara/dynamictp/test/core/plugin/InterceptTest.java
@@ -17,7 +17,7 @@
 
 package org.dromara.dynamictp.test.core.plugin;
 
-import cn.hutool.core.collection.CollectionUtil;
+import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 import org.dromara.dynamictp.common.plugin.DtpInterceptorRegistry;
 import org.junit.jupiter.api.Test;
@@ -55,7 +55,7 @@ class InterceptTest {
         DtpInterceptorRegistry.register("TestAInterceptor", interceptorTest);
 
         TestA testA = new TestA();
-        TestA testA1 = (TestA) DtpInterceptorRegistry.plugin(testA, CollectionUtil.newHashSet("TestAInterceptor"));
+        TestA testA1 = (TestA) DtpInterceptorRegistry.plugin(testA, Sets.newHashSet("TestAInterceptor"));
 
         assertTrue(testA1.getClass().getSimpleName().startsWith("InterceptTest$TestA$ByteBuddy$"));
         assertTrue(testA.getClass().isAssignableFrom(testA1.getClass()));


### PR DESCRIPTION
## 背景

当前项目对 Hutool 的使用非常轻量，仅涉及 HTTP 请求、URL 构建、Bean 操作等少量工具方法，并无深度依赖。引入 Hutool 作为强依赖增加了不必要的依赖体积，实际上这些功能均可通过原生 Java API 或项目已有的第三方库（Apache Commons 等）轻松替代，因此移除 Hutool 是合理且必要的。

## 概述

移除项目对 Hutool（hutool-core + hutool-http）的依赖，替换为原生 Java API 及已有第三方库，减少不必要的第三方依赖体积。

## 主要改动

| 模块 | 原 Hutool 用途 | 替换方案 |
|------|---------------|---------|
| AbstractHttpNotifier | HttpRequest / HttpResponse 发送通知 | 原生 HttpURLConnection，增强异常捕获与 HTTP 状态码日志 |
| UrlBuilder（新增） | UrlBuilder 构建 URL | 自实现轻量 UrlBuilder，支持 path/query 操作 |
| BeanUtil（新增） | BeanUtil Bean 操作 | 自实现 BeanUtil，覆盖实际使用场景 |
| FastJsonParser | fastjson 1.x | 迁移至 fastjson2 |
| 其他工具类 | StrUtil / CollUtil / NumberUtil 等 | Apache Commons Lang / Collections 原生替换 |

- 移除 dependencies/pom.xml 中 hutool-core、hutool-http 依赖声明
- common/pom.xml 中 fastjson 升级为 fastjson2

## 测试

- [x] mvn compile 全模块编译通过
- [x] test-common 模块 158 个测试全部通过
- [x] test-core 通知器相关测试全部通过
